### PR TITLE
[_]: fix/allow-product-currency-parametrization-on-checkout

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -622,7 +622,7 @@ export class PaymentService {
       customer_email: typeof prefill === 'string' ? prefill : undefined,
       line_items: lineItems,
       automatic_tax: { enabled: false },
-      currency: selectedPrice.currency,
+      currency: productCurrency,
       mode,
       discounts: couponCode ? [{ coupon: couponCode }] : undefined,
       allow_promotion_codes: couponCode ? undefined : true,


### PR DESCRIPTION
Use the currency that the user has selected in the client side to create the checkout. 

Currently, when the user selects a plan to pay with $, € is displayed because, when the checkout is created, the default currency of the product is used.

Now, we use the currency that the user selected in the client directly because the plans have been created as multi-currency products.