### PR TITLE
[MKT-408]: feat/use promotion code ID instead of coupon ID

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -396,7 +396,6 @@ export default function (
       } catch (error) {
         const err = error as Error;
         if (err instanceof NotFoundPromoCodeByNameError) {
-          console.log('SI');
           return rep.status(404).send({ message: err.message });
         }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -460,6 +460,7 @@ export default function (
           priceId: price_id,
           successUrl: success_url,
           cancelUrl: cancel_url,
+          customerId: user?.customerId,
           prefill: user ?? customer_email,
           mode: (mode as Stripe.Checkout.SessionCreateParams.Mode) || 'subscription',
           trialDays: trial_days,

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -609,7 +609,7 @@ export class PaymentService {
     prefill: User | string;
     mode: Stripe.Checkout.SessionCreateParams.Mode;
     trialDays?: number;
-    couponCode?: string;
+    couponCode?: Stripe.PromotionCode['id'];
     currency?: string;
     seats?: number;
   }): Promise<Stripe.Checkout.Session> {
@@ -659,7 +659,7 @@ export class PaymentService {
       automatic_tax: { enabled: false },
       currency: productCurrency,
       mode,
-      discounts: couponCode ? [{ coupon: couponCode }] : undefined,
+      discounts: couponCode ? [{ promotion_code: couponCode }] : undefined,
       allow_promotion_codes: couponCode ? undefined : true,
       billing_address_collection: 'required',
       ...invoiceCreation,

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -79,6 +79,7 @@ export interface PlanSubscription {
 }
 
 export interface PromotionCode {
+  promoCodeName: Stripe.PromotionCode['code'];
   codeId: Stripe.PromotionCode['id'];
   amountOff: Stripe.PromotionCode['coupon']['amount_off'];
   percentOff: Stripe.PromotionCode['coupon']['percent_off'];
@@ -586,6 +587,7 @@ export class PaymentService {
     const lastActiveCoupon = await this.getPromotionCodeObject(promoCodeName);
 
     return {
+      promoCodeName,
       codeId: lastActiveCoupon.id,
       amountOff: lastActiveCoupon.coupon.amount_off,
       percentOff: lastActiveCoupon.coupon.percent_off,


### PR DESCRIPTION
## Context
In production, the coupon ID is used to create the session with the discount automatically added. Now, the promotion code ID is used to do so.

## Description
Using the promotion code Id and not the coupon Id gives us the advantage of being able to use disposable promo codes. That is, we can configure them with an expiration date to be unusable, so we can use the promotion code (the same code that is added in the checkout when the user must add it manually). This allows us to have more flexibility when redeeming coupons.

## Changes in the codebase
Now, the promotion code ID and not the coupon ID is used when creating the checkout. And because of this, an endpoint has been enabled to get the promotion code information by name, where you get the id, the percentage/fixed price that is discounted.

The same flow is maintained as it is now. The coupon information is obtained from the website, where the id will be sent to drive-web to create the checkout session with this promotion code id, and where finally the user will be redirected to the Stripe checkout.