### PR TITLE
[PB-2382]: feat/validate existing subscriptions when creating checkout session

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,7 @@ const start = async (): Promise<FastifyInstance> => {
   const productsRepository: ProductsRepository = new MongoDBProductsRepository(mongoClient);
 
   const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' });
-  const paymentService = new PaymentService(stripe, productsRepository);
+  const paymentService = new PaymentService(stripe, productsRepository, usersRepository);
   const storageService = new StorageService(envVariablesConfig, axios);
   const usersService = new UsersService(
     usersRepository,

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { DisplayPrice } from '../core/users/DisplayPrice';
 import { User, UserSubscription, UserType } from '../core/users/User';
 import { ProductsRepository } from '../core/users/ProductsRepository';
+import { UsersRepository } from '../core/users/UsersRepository';
 
 type Customer = Stripe.Customer;
 export type CustomerId = Customer['id'];
@@ -111,10 +112,12 @@ export interface PromotionCode {
 export class PaymentService {
   private readonly provider: Stripe;
   private readonly productsRepository: ProductsRepository;
+  private readonly usersRepository: UsersRepository;
 
-  constructor(provider: Stripe, productsRepository: ProductsRepository) {
+  constructor(provider: Stripe, productsRepository: ProductsRepository, usersRepository: UsersRepository) {
     this.provider = provider;
     this.productsRepository = productsRepository;
+    this.usersRepository = usersRepository;
   }
 
   async createCustomer(payload: Stripe.CustomerCreateParams): Promise<Stripe.Customer> {
@@ -753,6 +756,24 @@ export class PaymentService {
     };
   }
 
+  async checkActiveSubscriptions(customerId: string, productType: UserType): Promise<void> {
+    let activeSubscriptions;
+    try {
+      activeSubscriptions =
+        productType === 'business'
+          ? await this.findBusinessActiveSubscription(customerId)
+          : await this.findIndividualActiveSubscription(customerId);
+    } catch (error) {
+      if (!(error instanceof NotFoundSubscriptionError)) {
+        throw error;
+      }
+    }
+
+    if (activeSubscriptions) {
+      throw new ExistingSubscriptionError('User already has an active subscription of the same type');
+    }
+  }
+
   async getCheckoutSession({
     customerId,
     priceId,
@@ -790,6 +811,13 @@ export class PaymentService {
     );
 
     if (!selectedPrice) throw new Error('The product does not exist');
+
+    const customerIsRegistered = customerId ? await this.getCustomer(customerId) : undefined;
+    const newPriceIsNotLifetime = selectedPrice.type !== 'one_time';
+
+    if (customerIsRegistered && newPriceIsNotLifetime && customerId) {
+      await this.checkActiveSubscriptions(customerId, (product.metadata.type as UserType) || UserType.Individual);
+    }
 
     let lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [{ price: priceId, quantity: 1 }];
     if (product.metadata?.type === 'business') {
@@ -980,5 +1008,13 @@ export class NotFoundPromoCodeByNameError extends Error {
     super(`Promotion code with an id ${promoCodeId} does not exist`);
 
     Object.setPrototypeOf(this, NotFoundPromoCodeByNameError.prototype);
+  }
+}
+
+export class ExistingSubscriptionError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, ExistingSubscriptionError.prototype);
   }
 }


### PR DESCRIPTION
Added a check right before creating the checkout session to prevent the purchase of more than one subscription of the same type (individual, business). This check is skipped for lifetime plans.