### PR TITLE
[_]: fix/exclude-business-products-from-invoice-payment-succeeded

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -1027,13 +1027,13 @@ export class PaymentService {
 
   async getCheckoutLineItems(checkoutSessionId: string) {
     return this.provider.checkout.sessions.listLineItems(checkoutSessionId, {
-      expand: ['data.price.product', 'data.discounts'],
+      expand: ['data.price.product'],
     });
   }
 
   async getInvoiceLineItems(invoiceId: string) {
     return this.provider.invoices.listLineItems(invoiceId, {
-      expand: ['data.price.product'],
+      expand: ['data.price.product', 'data.discounts'],
     });
   }
 


### PR DESCRIPTION
Check that the payment is not for a b2b product to proceed with the logic of `invoices.payment_succeeded`