### PR TITLE
[_]: feat/subscribe-first-and-then-verify-card-funds-on-object-storage

### DIFF
--- a/src/services/ObjectStorageService.ts
+++ b/src/services/ObjectStorageService.ts
@@ -19,16 +19,17 @@ export class ObjectStorageService {
 
   async initObjectStorageUser(payload: {
     email: string;
+    paymentMethodId: string;
     customerId: string,
     currency: string
   }) {
-    const { email, customerId, currency } = payload;
+    const { email, customerId, currency, paymentMethodId } = payload;
 
-    await this.paymentService.createSubscription(
-      customerId, 
-      this.config.STRIPE_OBJECT_STORAGE_PRICE_ID, 
-      currency
-    );
+    await this.paymentService.billCardVerificationCharge(
+      customerId,
+      paymentMethodId,
+      currency,
+    )
     await this.createUser(email, customerId);
   }
 

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -140,6 +140,23 @@ export class PaymentService {
     return customer;
   }
 
+  async billCardVerificationCharge(
+    customerId: string,
+    paymentMethodId: string,
+    currency: string,
+  ) {
+    const paymentIntent = await this.provider.paymentIntents.create({
+      amount: 1,
+      currency,
+      customer: customerId,
+      description: 'Card verification charge',
+      payment_method: paymentMethodId,
+      off_session: true,
+      confirm: true,
+    });
+
+  }
+
   async createSubscription(
     customerId: string,
     priceId: string,

--- a/src/webhooks/handleSubscriptionCreated.ts
+++ b/src/webhooks/handleSubscriptionCreated.ts
@@ -1,0 +1,52 @@
+import Stripe from 'stripe';
+
+import { PaymentService } from '../services/PaymentService';
+import { ObjectStorageService } from '../services/ObjectStorageService';
+
+function isProduct(product: Stripe.Product | Stripe.DeletedProduct): product is Stripe.Product {
+  return (product as Stripe.Product).metadata !== undefined;
+}
+
+function isObjectStorageSubscription(item: Stripe.SubscriptionItem): boolean {
+  return (
+    typeof item.price?.product === 'object' &&
+    isProduct(item.price?.product) &&
+    !!item.price.product.metadata.type &&
+    item.price.product.metadata.type === 'object-storage'
+  );
+}
+
+
+export default async function handleSubscriptionCreated(
+  subscription: Stripe.Subscription,
+  paymentService: PaymentService,
+  objectStorageService: ObjectStorageService,
+): Promise<void> {
+  const customerId = subscription.customer as string;
+  const { items, currency } = subscription;
+  const customer = await paymentService.getCustomer(customerId) as Stripe.Customer;
+
+  if (!customer.deleted) {
+    throw new Error('Customer has been deleted')
+  }
+
+  if (isObjectStorageSubscription(items.data[0])) {
+    if (!customer.email) {
+      throw new Error('Missing customer email on subscription created');
+    }
+
+    const paymentMethodId = subscription.default_payment_method as string;
+
+    if (!paymentMethodId) {
+      throw new Error('No default payment method has been set')
+    }
+
+
+    await objectStorageService.initObjectStorageUser({
+      email: customer.email,
+      currency,
+      customerId: customer.id,
+      paymentMethodId,
+    })
+  }
+}

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -12,6 +12,7 @@ import handleLifetimeRefunded from './handleLifetimeRefunded';
 import handleSetupIntentSucceded from './handleSetupIntentSucceded';
 import handleCheckoutSessionCompleted from './handleCheckoutSessionCompleted';
 import { ObjectStorageService } from '../services/ObjectStorageService';
+import handleSubscriptionCreated from './handleSubscriptionCreated';
 
 export default function (
   stripe: Stripe,
@@ -45,6 +46,14 @@ export default function (
       fastify.log.info(`Stripe event received: ${event.type}, id: ${event.id}`);
 
       switch (event.type) {
+        case 'customer.subscription.created':
+          await handleSubscriptionCreated(
+            event.data.object as Stripe.Subscription,
+            paymentService,
+            objectStorageService,
+          );
+          break;
+
         case 'customer.subscription.deleted':
           await handleSubscriptionCanceled(
             storageService,
@@ -96,8 +105,7 @@ export default function (
             paymentService,
             fastify.log,
             cacheService,
-            config,
-            objectStorageService,
+            config
           );
           break;
 


### PR DESCRIPTION
Changes: 
- Stop using `invoice.payment_succeeded` for initializing an object storage user
- Start using `customer.subscription.created` for initializing an object storage user
- Apply the verification card charge to an object storage user on the background