### PR TITLE
[_]: feat/basic-object-storage-account-lifecycle-management

### DIFF
--- a/src/services/ObjectStorageService.ts
+++ b/src/services/ObjectStorageService.ts
@@ -32,6 +32,38 @@ export class ObjectStorageService {
     await this.createUser(email, customerId);
   }
 
+  async reactivateAccount(payload: { customerId : string }): Promise<void> {
+    const jwt = signToken('5m', this.config.OBJECT_STORAGE_GATEWAY_SECRET);
+    const params: AxiosRequestConfig = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt}`,
+      },
+    };
+
+    await this.axios.put(
+      `${this.config.OBJECT_STORAGE_URL}/users/${payload.customerId}/reactivate`,
+      {},
+      params,
+    );
+  }
+
+  async suspendAccount(payload: { customerId : string }): Promise<void> {
+    const jwt = signToken('5m', this.config.OBJECT_STORAGE_GATEWAY_SECRET);
+    const params: AxiosRequestConfig = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt}`,
+      },
+    };
+
+    await this.axios.put(
+      `${this.config.OBJECT_STORAGE_URL}/users/${payload.customerId}/deactivate`,
+      {},
+      params,
+    );
+  }
+
   private async createUser(
     email: string,
     customerId: string

--- a/src/webhooks/handleInvoicePaymentFailed.ts
+++ b/src/webhooks/handleInvoicePaymentFailed.ts
@@ -1,0 +1,52 @@
+import Stripe from 'stripe';
+import { PaymentService } from '../services/PaymentService';
+import { ObjectStorageService } from '../services/ObjectStorageService';
+
+function isProduct(product: Stripe.Product | Stripe.DeletedProduct): product is Stripe.Product {
+  return (product as Stripe.Product).metadata !== undefined;
+}
+
+/**
+ * This function only handles the Object Storage sub payment failed
+ * @param invoice 
+ * @param objectStorageService 
+ * @param paymentService 
+ * @returns 
+ */
+export default async function handleInvoicePaymentFailed(
+  invoice: Stripe.Invoice,
+  objectStorageService: ObjectStorageService,
+  paymentService: PaymentService,
+): Promise<void> {
+  console.log('invoice', invoice);
+
+  if (!invoice.customer) {
+    throw new Error('No customer found for this payment');
+  }
+
+  if (!invoice.subscription) {
+    // We are looking for invoices failed to be paid by a subscription
+    return;
+  }
+
+  if (invoice.lines.data.length !== 1) {
+    throw new Error(`Unexpected invoice lines count for invoice ${invoice.id}`);
+  } 
+
+  const [{ plan }] = invoice.lines.data;
+
+  if (!plan) {
+    throw new Error(`Product not found for not paid invoice ${invoice.id}`);
+  }
+
+  const product = await paymentService.getProduct(plan.product as string);
+
+  if (!isProduct(product)) {
+    throw new Error(`Unexpected product ${plan.id} for not paid invoice ${invoice.id}`);
+  }
+
+  const customer = await paymentService.getCustomer(invoice.customer as string) as Stripe.Customer;
+
+
+  await objectStorageService.suspendAccount({ customerId: customer.id });
+}

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -12,6 +12,7 @@ import handleLifetimeRefunded from './handleLifetimeRefunded';
 import handleSetupIntentSucceded from './handleSetupIntentSucceded';
 import handleCheckoutSessionCompleted from './handleCheckoutSessionCompleted';
 import { ObjectStorageService } from '../services/ObjectStorageService';
+import handleInvoicePaymentFailed from './handleInvoicePaymentFailed';
 
 export default function (
   stripe: Stripe,
@@ -45,6 +46,14 @@ export default function (
       fastify.log.info(`Stripe event received: ${event.type}, id: ${event.id}`);
 
       switch (event.type) {
+        case 'invoice.payment_failed':
+          await handleInvoicePaymentFailed(
+            event.data.object as Stripe.Invoice,
+            objectStorageService,
+            paymentService,
+          );
+          break;
+
         case 'customer.subscription.deleted':
           await handleSubscriptionCanceled(
             storageService,


### PR DESCRIPTION
Changes: 

- Adds a basic handling of the lifecycle of an Object Storage user 
  - If the `invoice.payment_failed` triggers, the account is deactivated
  - If the `invoice.payment_succeeded` triggers, the account is reactivated (if proceeds)

#### What's missing?
- Automate the account removal signal if the payment_failed happens more than N times.

This is not still included as we do not offer a way of changing the payment method on the current Object Storage UI, therefore situations like expired cards could happen, thus, we do not want to perform an account removal of a customer who has been paying properly for years and forgot to change the card used to pay.