### PR TITLE
[_]: fix/undefined client secret for invoices with 100% off discount

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -629,7 +629,7 @@ export default function (
       }
 
       try {
-        const { clientSecret, id } = await paymentService.createPaymentIntent(
+        const { clientSecret, id, invoiceStatus } = await paymentService.createPaymentIntent(
           customerId,
           amount,
           planId,
@@ -637,7 +637,7 @@ export default function (
           promoCodeName,
         );
 
-        return { clientSecret, id };
+        return { clientSecret, id, invoiceStatus };
       } catch (err) {
         const error = err as Error;
         if (error instanceof MissingParametersError || error instanceof PromoCodeIsNotValidError) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -640,11 +640,18 @@ export default function (
         return { clientSecret, id, invoiceStatus };
       } catch (err) {
         const error = err as Error;
-        if (error instanceof MissingParametersError || error instanceof PromoCodeIsNotValidError) {
+        if (error instanceof MissingParametersError) {
           return res.status(404).send({
             message: error.message,
           });
         }
+
+        if(error instanceof PromoCodeIsNotValidError){
+          return res.status(400).send({
+            message: error.message
+          });
+        }
+
         req.log.error(`[ERROR WHILE CREATING PAYMENT INTENT]: ${error.stack ?? error.message}`);
         return res.status(500).send({
           message: 'Internal Server Error',

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -56,6 +56,7 @@ export interface SubscriptionCreated {
 export interface PaymentIntent {
   clientSecret: string | null;
   id: string;
+  invoiceStatus?: string;
 }
 
 export type Reason = {
@@ -260,7 +261,7 @@ export class PaymentService {
     priceId: string,
     currency?: string,
     promoCodeId?: Stripe.PromotionCode['id'],
-  ): Promise<PaymentIntent & { invoiceStatus?: string }> {
+  ): Promise<PaymentIntent> {
     let couponId;
     const currencyValue = currency ?? 'eur';
 


### PR DESCRIPTION
The invoice for “free” one time payments (amount = 0€) is paid at the time it is created, so the customer secret does not exist. To solve this problem, we send the invoice status to the customer to avoid payment confirmation, only if the `status = 'paid'`.