### PR TITLE
[_]: fix/avoid canceling business sub, avoid updating the lifetime field when it is not needed and return the correct sub for each user type

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -794,6 +794,8 @@ export default function (
         const user: User = await assertUser(req, rep);
         const userType = (req.query.userType as UserType) || UserType.Individual;
 
+        const isLifetimeUser = user.lifetime && userType === UserType.Individual;
+
         let subscriptionInCache: UserSubscription | null | undefined;
         try {
           subscriptionInCache = await cacheService.getSubscription(user.customerId, userType);
@@ -807,7 +809,7 @@ export default function (
           return subscriptionInCache;
         }
 
-        if (user.lifetime && userType === UserType.Individual) {
+        if (isLifetimeUser) {
           response = { type: 'lifetime' };
         } else {
           response = await paymentService.getUserSubscription(user.customerId, userType);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -807,7 +807,7 @@ export default function (
           return subscriptionInCache;
         }
 
-        if (user.lifetime) {
+        if (user.lifetime && userType === UserType.Individual) {
           response = { type: 'lifetime' };
         } else {
           response = await paymentService.getUserSubscription(user.customerId, userType);

--- a/src/webhooks/handleInvoiceCompleted.ts
+++ b/src/webhooks/handleInvoiceCompleted.ts
@@ -102,13 +102,13 @@ export default async function handleInvoiceCompleted(
 
   try {
     const userActiveSubscription = await paymentService.getActiveSubscriptions(customer.id);
-    const hasActiveSubscription = userActiveSubscription.length > 0;
     const hasIndividualActiveSubscription = userActiveSubscription.find(
       (sub) =>
         sub.product?.metadata.type !== UserType.Business && sub.product?.metadata.type !== UserType.ObjectStorage,
     );
+    const shouldCancelCurrentActiveSubscription = isLifetimePlan && hasIndividualActiveSubscription;
 
-    if (isLifetimePlan && hasActiveSubscription && hasIndividualActiveSubscription) {
+    if (shouldCancelCurrentActiveSubscription) {
       await paymentService.cancelSubscription(hasIndividualActiveSubscription.id);
     }
   } catch (error) {

--- a/src/webhooks/handleInvoiceCompleted.ts
+++ b/src/webhooks/handleInvoiceCompleted.ts
@@ -103,9 +103,13 @@ export default async function handleInvoiceCompleted(
   try {
     const userActiveSubscription = await paymentService.getActiveSubscriptions(customer.id);
     const hasActiveSubscription = userActiveSubscription.length > 0;
+    const hasIndividualActiveSubscription = userActiveSubscription.find(
+      (sub) =>
+        sub.product?.metadata.type !== UserType.Business && sub.product?.metadata.type !== UserType.ObjectStorage,
+    );
 
-    if (isLifetimePlan && hasActiveSubscription) {
-      await paymentService.cancelSubscription(userActiveSubscription[0].id);
+    if (isLifetimePlan && hasActiveSubscription && hasIndividualActiveSubscription) {
+      await paymentService.cancelSubscription(hasIndividualActiveSubscription.id);
     }
   } catch (error) {
     log.error(
@@ -154,8 +158,10 @@ export default async function handleInvoiceCompleted(
   }
 
   try {
+    const { lifetime } = await usersService.findUserByCustomerID(customer.id);
+    const isLifetimeCurrentSub = isBusinessPlan ? lifetime : isLifetimePlan;
     await usersService.updateUser(customer.id, {
-      lifetime: isLifetimePlan,
+      lifetime: isLifetimeCurrentSub,
     });
   } catch {
     await usersService.insertUser({


### PR DESCRIPTION
- Return the correct plan for both individual and subscriptions, because when the individual sub is lifetime, `type=lifetime` is returned for both subs (individual and business).
- Prevent cancellation of business subscriptions when the product is an individual lifetime. Now we filter the product and check if is for individuals before canceling it.
- Prevent lifetime field update if the sub is not individual.