### PR TITLE
[PB-3407]: fix/wrong plan display when partial refund is made for lifetime plans

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: 'https://npm.pkg.github.com'
-      - run: echo REACT_APP_NODE_ENV=test >> ./.env
+      - run: echo NODE_ENV=test >> ./.env
       - run: echo SERVER_PORT=8000 >> ./.env
       - run: echo STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }} >> ./.env
       - run: echo JWT_SECRET=JWT_SECRET >> ./.env

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -148,14 +148,18 @@ export default function (
           if (event.data.object.metadata.type === 'object-storage') {
             // no op
           } else {
-            await handleLifetimeRefunded(
-              storageService,
-              usersService,
-              event.data.object.customer as string,
-              cacheService,
-              fastify.log,
-              config,
-            );
+            const isFullAmountRefunded = event.data.object.refunded;
+
+            if (isFullAmountRefunded) {
+              await handleLifetimeRefunded(
+                storageService,
+                usersService,
+                event.data.object.customer as string,
+                cacheService,
+                fastify.log,
+                config,
+              );
+            }
           }
           break;
 


### PR DESCRIPTION
Before updating the user's lifetime status and storage, we check whether the payment is [fully refunded](https://docs.stripe.com/api/charges/object#charge_object-refunded) or not to do that. So when we do a partial refund, the user keeps both the Lifetime label and the space purchased in Drive.