### PR TITLE
[_]: fix/charge.disputes.closed webhook for lost disputes

### DIFF
--- a/src/webhooks/handleDisputeResult.ts
+++ b/src/webhooks/handleDisputeResult.ts
@@ -40,10 +40,14 @@ export async function handleDisputeResult({
 
     const { subscription: subscriptionId } = await stripe.invoices.retrieve(invoiceId as string);
     const { lifetime } = await usersService.findUserByCustomerID(customerId);
+    const activeSubscription = await stripe.subscriptions.retrieve(subscriptionId as string);
 
     if (lifetime) {
       await handleLifetimeRefunded(storageService, usersService, customerId, cacheService, log, config);
     } else {
+      if (!activeSubscription || activeSubscription.status !== 'active') {
+        return;
+      }
       await paymentService.cancelSubscription(subscriptionId as string);
     }
   } catch (error) {


### PR DESCRIPTION
Try to Cancel Subscription when the Subscription is not already cancelled. If it is already cancelled, it means that the upgrade to free plan has been done and the only thing left to do is to return the money, so we don't have to do anything.