### PR TITLE
[PB-3306]: fix/get the saved payment method for lifetime users

### DIFF
--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -760,9 +760,9 @@ export default function (
         },
       },
       async (req, rep) => {
-        const user = await assertUser(req, rep, usersService);
+        const { customerId, lifetime } = await assertUser(req, rep, usersService);
         const userType = (req.query.userType as UserType) || UserType.Individual;
-        return paymentService.getDefaultPaymentMethod(user.customerId, userType);
+        return paymentService.getDefaultPaymentMethod(customerId, lifetime, userType);
       },
     );
 


### PR DESCRIPTION
When a user who has a lifetime plan saves a setup intent (option allowed to users in drive-web), then we will return this setup intent for them.