### PR TITLE
[PB-3585]: fix/filter invoices depending on the item type

### DIFF
--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -478,7 +478,7 @@ export default function (
 
         const user = await assertUser(req, rep, usersService);
 
-        const userInvoices = paymentService.getDriveInvoices(
+        const userInvoices = await paymentService.getDriveInvoices(
           user.customerId,
           {
             limit,

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -491,13 +491,14 @@ export default function (
         );
 
         const invoicesMapped = invoices
-          .filter(
-            (invoice) =>
-              invoice.created &&
-              invoice.invoice_pdf &&
-              invoice.lines?.data?.[0]?.price?.metadata?.maxSpaceBytes &&
-              invoice.lines?.data?.[0]?.price?.metadata?.type !== 'object-storage' &&
-              invoiceType(invoice),
+          .filter((invoice) =>
+            invoice.created &&
+            invoice.invoice_pdf &&
+            invoice.lines?.data?.[0]?.price?.metadata?.maxSpaceBytes &&
+            invoice.lines?.data?.[0]?.price?.metadata?.type !== 'object-storage' &&
+            subscriptionId
+              ? true
+              : invoiceType(invoice),
           )
           .map((invoice) => {
             return {

--- a/tests/src/mocks/index.ts
+++ b/tests/src/mocks/index.ts
@@ -208,10 +208,48 @@ export default function getMocks() {
     currency: mockCharge.currency,
   };
 
-  const mockInvoice = {
-    id: `in_${randomUUID()}`,
-    subscription: `sub_${randomUUID()}`,
-  };
+  const mockInvoices = [
+    {
+      id: `in_${randomUUID()}`,
+      created: 1640995200,
+      invoice_pdf: 'https://example.com/inv_1.pdf',
+      lines: {
+        data: [
+          {
+            price: {
+              metadata: {
+                maxSpaceBytes: '1073741824',
+                type: 'individual',
+              },
+            },
+          },
+        ],
+      },
+      total: 1000,
+      currency: 'usd',
+      subscription: `sub_${randomUUID()}`,
+    },
+    {
+      id: `in_${randomUUID()}`,
+      created: 1640995300,
+      invoice_pdf: 'https://example.com/inv_2.pdf',
+      lines: {
+        data: [
+          {
+            price: {
+              metadata: {
+                maxSpaceBytes: '2147483648',
+                type: 'business',
+              },
+            },
+          },
+        ],
+      },
+      total: 2000,
+      currency: 'usd',
+      subscription: `sub_${randomUUID()}`,
+    },
+  ];
 
   const mockLogger: jest.Mocked<FastifyBaseLogger> = {
     info: jest.fn(),
@@ -234,7 +272,7 @@ export default function getMocks() {
       billingType: 'subscription',
       label: 'test-label',
       productId: randomDataGenerator.string({
-        length: 15
+        length: 15,
       }),
       featuresPerService: {
         mail: {
@@ -248,47 +286,47 @@ export default function getMocks() {
           enabled: false,
           paxPerCall: randomDataGenerator.integer({
             min: 0,
-            max: 5
+            max: 5,
           }),
         },
         vpn: {
           enabled: false,
           locationsAvailable: randomDataGenerator.integer({
             min: 0,
-            max: 5
-          })
+            max: 5,
+          }),
         },
         antivirus: {
           enabled: false,
         },
         backups: {
           enabled: false,
-        }, 
+        },
         drive: {
           enabled: false,
           maxSpaceBytes: randomDataGenerator.integer({
             max: 5 * 1024 * 1024 * 1024,
-            min: 1024 * 1024 * 1024
+            min: 1024 * 1024 * 1024,
           }),
           workspaces: {
             enabled: false,
             maximumSeats: randomDataGenerator.integer({
               max: 100,
-              min: 10
+              min: 10,
             }),
             minimumSeats: randomDataGenerator.integer({
               min: 3,
-              max: 3
+              max: 3,
             }),
             maxSpaceBytesPerSeat: randomDataGenerator.integer({
               max: 5 * 1024 * 1024 * 1024,
-              min: 1024 * 1024 * 1024
-            })
-          }
-        }
+              min: 1024 * 1024 * 1024,
+            }),
+          },
+        },
       },
-      ...params
-    }
+      ...params,
+    };
   }
 
   const voidPromise = () => Promise.resolve();
@@ -303,7 +341,7 @@ export default function getMocks() {
     couponName,
     mockCharge,
     mockDispute,
-    mockInvoice,
+    mockInvoices,
     mockLogger,
     mockedCustomerPayload,
     createdSubscriptionPayload,

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -258,53 +258,15 @@ describe('Payments Service tests', () => {
   });
 
   describe('getDriveInvoices()', () => {
-    const mockCustomerId = 'test-customer-id';
+    const mockCustomerId = mocks.mockedUserWithoutLifetime.customerId;
     const mockPagination = { limit: 10, startingAfter: 'inv_123' };
-    const mockSubscriptionId = 'sub_123';
+    const mockSubscriptionId = mocks.mockActiveSubscriptions[0].id;
 
-    const mockInvoices = [
-      {
-        id: 'inv_1',
-        created: 1640995200,
-        invoice_pdf: 'https://example.com/inv_1.pdf',
-        lines: {
-          data: [
-            {
-              price: {
-                metadata: {
-                  maxSpaceBytes: '1073741824',
-                  type: 'individual',
-                },
-              },
-            },
-          ],
-        },
-        total: 1000,
-        currency: 'usd',
-      },
-      {
-        id: 'inv_2',
-        created: 1640995300,
-        invoice_pdf: 'https://example.com/inv_2.pdf',
-        lines: {
-          data: [
-            {
-              price: {
-                metadata: {
-                  maxSpaceBytes: '2147483648',
-                  type: 'business',
-                },
-              },
-            },
-          ],
-        },
-        total: 2000,
-        currency: 'usd',
-      },
-    ];
+    const { mockInvoices } = mocks;
 
     beforeEach(() => {
       jest.clearAllMocks();
+      jest.spyOn(paymentService, 'getInvoicesFromUser').mockResolvedValue(mockInvoices as unknown as Stripe.Invoice[]);
     });
 
     it('When userType is Individual, then returns filtered invoices with individual type', async () => {
@@ -315,7 +277,7 @@ describe('Payments Service tests', () => {
       expect(paymentService.getInvoicesFromUser).toHaveBeenCalledWith(mockCustomerId, mockPagination, undefined);
       expect(result).toEqual([
         {
-          id: 'inv_1',
+          id: mockInvoices[0].id,
           created: mockInvoices[0].created,
           pdf: mockInvoices[0].invoice_pdf,
           bytesInPlan: mockInvoices[0].lines.data[0].price.metadata.maxSpaceBytes,
@@ -333,7 +295,7 @@ describe('Payments Service tests', () => {
       expect(paymentService.getInvoicesFromUser).toHaveBeenCalledWith(mockCustomerId, mockPagination, undefined);
       expect(result).toEqual([
         {
-          id: 'inv_2',
+          id: mockInvoices[1].id,
           created: mockInvoices[1].created,
           pdf: mockInvoices[1].invoice_pdf,
           bytesInPlan: mockInvoices[1].lines.data[0].price.metadata.maxSpaceBytes,

--- a/tests/src/webhooks/handleDisputeResult.test.ts
+++ b/tests/src/webhooks/handleDisputeResult.test.ts
@@ -45,7 +45,7 @@ jest.mock('../../../src/services/cache.service', () => {
 
 const {
   mockCharge,
-  mockInvoice,
+  mockInvoices,
   mockedUserWithLifetime,
   mockedUserWithoutLifetime,
   mockDispute,
@@ -95,7 +95,7 @@ describe('handleDisputeResult()', () => {
   describe('Dispute Status is Lost', () => {
     it('When the status is lost and the user has a subscription, then the subscription is cancelled and the storage is downgraded', async () => {
       (stripe.charges.retrieve as jest.Mock).mockResolvedValue(mockCharge);
-      (stripe.invoices.retrieve as jest.Mock).mockResolvedValue(mockInvoice);
+      (stripe.invoices.retrieve as jest.Mock).mockResolvedValue(mockInvoices[0]);
       (usersRepository.findUserByCustomerId as jest.Mock).mockResolvedValue(mockedUserWithoutLifetime);
       jest.spyOn(paymentService, 'cancelSubscription').mockImplementation(voidPromise);
 
@@ -113,12 +113,12 @@ describe('handleDisputeResult()', () => {
       expect(stripe.charges.retrieve).toHaveBeenCalledWith(mockCharge.id);
       expect(stripe.invoices.retrieve).toHaveBeenCalledWith(mockCharge.invoice);
       expect(usersRepository.findUserByCustomerId).toHaveBeenCalledWith(mockCharge.customer);
-      expect(paymentService.cancelSubscription).toHaveBeenCalledWith(mockInvoice.subscription);
+      expect(paymentService.cancelSubscription).toHaveBeenCalledWith(mockInvoices[0].subscription);
     });
 
     it('When the status is lost and the user has a lifetime, then the lifetime param is changed to false and the storage is downgraded', async () => {
       (stripe.charges.retrieve as jest.Mock).mockResolvedValue(mockCharge);
-      (stripe.invoices.retrieve as jest.Mock).mockResolvedValue(mockInvoice);
+      (stripe.invoices.retrieve as jest.Mock).mockResolvedValue(mockInvoices);
       (usersRepository.findUserByCustomerId as jest.Mock).mockResolvedValue(mockedUserWithLifetime);
       (handleLifetimeRefunded as jest.Mock).mockImplementation(voidPromise);
       jest.spyOn(usersService, 'updateUser').mockImplementation(voidPromise);
@@ -154,7 +154,7 @@ describe('handleDisputeResult()', () => {
       mockDispute.status = 'needs_response';
 
       (stripe.charges.retrieve as jest.Mock).mockResolvedValue(mockCharge);
-      (stripe.invoices.retrieve as jest.Mock).mockResolvedValue(mockInvoice);
+      (stripe.invoices.retrieve as jest.Mock).mockResolvedValue(mockInvoices);
       (usersRepository.findUserByCustomerId as jest.Mock).mockResolvedValue(mockedUserWithLifetime);
       (handleLifetimeRefunded as jest.Mock).mockImplementation(voidPromise);
       jest.spyOn(paymentService, 'cancelSubscription').mockImplementation(voidPromise);


### PR DESCRIPTION
To get the user invoices, it is necessary to use the `userType` query parameter to filter the invoices based on the product type.

If the user wants `business invoices`, then the invoices will be filtered to get ONLY business product invoices. Otherwise, the endpoint will return ONLY the `individual invoices` (subscription + lifetime).

Object storage invoices have been automatically avoided.

**Nice to know**
The filter will be only applied if the `subscription Id` is not sent, as it does not make sense to filter by `userType` if the request is made for a specific `subscription Id`.