### PR TITLE
[_]: tests/use functions for mocks instead

### DIFF
--- a/tests/src/mocks/index.ts
+++ b/tests/src/mocks/index.ts
@@ -8,47 +8,41 @@ import { Tier } from '../../../src/core/users/MongoDBTiersRepository';
 
 const randomDataGenerator = new Chance();
 
-export default function getMocks() {
-  const user = {
+export function user() {
+  return {
     customerId: 'cus_RbPFdWW7LCxL2c',
     uuid: '223b88d7-f5a0-4592-a76c-22758c074757',
     lifetime: false,
   };
-  const newUser = {
-    customerId: 'cus_123',
+}
+
+export function mockedUserWithoutLifetime(): User {
+  return {
+    id: randomUUID(),
     uuid: randomUUID(),
+    customerId: `cus_${randomUUID()}`,
     lifetime: false,
   };
-  const uniqueCode = {
-    techCult: {
-      codes: {
-        elegible: '5tb_redeem_code', //REDEEMED: FALSE
-        nonElegible: '2tb_code_redeem', //REDEEMED: TRUE
-        doesntExist: 'doesnt_exist',
-      },
-      provider: 'TECHCULT',
-    },
-    stackCommerce: {
-      codes: {
-        elegible: '5tb_redeem_code', //REDEEMED: FALSE
-        nonElegible: '2tb_code_redeem', //REDEEMED: TRUE
-        doesntExist: 'doesnt_exist',
-      },
-      provider: 'STACKCOMMERCE',
-    },
-  };
+}
 
-  const preventCancellationTestUsers = {
-    nonElegible: {
-      lifetimeUserUuid: 'ee4f8abf-397c-4558-b794-a675a4bed2d7',
-      subscriptionUserUuid: '48cef034-011b-4e75-9671-86928a2370e7',
-    },
-    elegible: {
-      subscriptionUserUuid: '223b88d7-f5a0-4592-a76c-22758c074757',
-    },
+export function mockedCustomerPayload() {
+  return {
+    email: 'test@example.com',
+    name: 'Test User',
   };
+}
 
-  const prices = {
+export function mockPromotionCodeResponse() {
+  return {
+    codeId: 'promo_id',
+    promoCodeName: 'PROMO_NAME',
+    amountOff: null,
+    discountOff: 75,
+  };
+}
+
+export function prices() {
+  return {
     subscription: {
       exists: 'price_1PLMh8FAOdcgaBMQlZcGAPY4',
       doesNotExist: 'price_1PLMerFAOdcgaBMQ17q27Cas',
@@ -58,167 +52,216 @@ export default function getMocks() {
       doesNotExist: 'price_1PLMVCFAOdcgaBMQxIQgdXsds',
     },
   };
+}
 
-  const mockPromotionCodeResponse = {
-    codeId: 'promo_id',
-    promoCodeName: 'PROMO_NAME',
-    amountOff: null,
-    discountOff: 75,
-  };
-  const mockCreateSubscriptionResponse = {
-    type: 'payment',
-    clientSecret: 'client_secret',
-  };
-  const paymentIntentResponse = {
-    clientSecret: 'client_secret',
-  };
-
-  const mockedCoupon = {
-    id: randomUUID(),
-    provider: 'stripe',
-    code: 'c0UP0n',
-  };
-
-  const couponName = {
+export function couponName() {
+  return {
     invalid: 'INVALID_COUPON',
     valid: 'PROMOCODE',
   };
+}
 
-  const mockedUserWithLifetime: User = {
-    id: randomUUID(),
-    uuid: randomUUID(),
-    customerId: `cus_${randomUUID()}`,
-    lifetime: true,
+export function mockCreateSubscriptionResponse() {
+  return {
+    type: 'payment',
+    clientSecret: 'client_secret',
   };
+}
 
-  const mockedUserWithoutLifetime: User = {
-    id: randomUUID(),
-    uuid: randomUUID(),
-    customerId: `cus_${randomUUID()}`,
-    lifetime: false,
-  };
-
-  const mockedCustomerPayload = {
-    email: 'test@example.com',
-    name: 'Test User',
-  };
-
-  const createdSubscriptionPayload = {
+export function createdSubscriptionPayload() {
+  return {
     customerId: 'cId',
     amount: 100,
     priceId: 'price_id',
     promotion_code: 'promo_code',
   };
+}
 
-  const mockActiveSubscriptions = [
-    {
-      id: 'sub_1ExampleBusiness',
-      object: 'subscription',
-      customer: 'cus_123456789',
-      status: 'active',
-      items: {
-        object: 'list',
-        data: [
-          {
-            id: 'si_12345',
-            object: 'subscription_item',
-            price: {
-              id: 'price_1ExampleBusiness',
-              object: 'price',
-              currency: 'usd',
-              unit_amount: 5000,
-              recurring: {
-                interval: 'month',
-                interval_count: 1,
-              },
-              product: {
-                id: 'prod_1ExampleBusiness',
-                object: 'product',
-                active: true,
-                metadata: {
-                  type: 'business',
-                },
-                name: 'Business Product',
-              },
+export function paymentIntentResponse() {
+  return {
+    clientSecret: 'client_secret',
+  };
+}
+
+export const mockActiveSubscriptions = () => [
+  {
+    id: 'sub_1ExampleBusiness',
+    object: 'subscription',
+    customer: 'cus_123456789',
+    status: 'active',
+    items: {
+      object: 'list',
+      data: [
+        {
+          id: 'si_12345',
+          object: 'subscription_item',
+          price: {
+            id: 'price_1ExampleBusiness',
+            object: 'price',
+            currency: 'usd',
+            unit_amount: 5000,
+            recurring: {
+              interval: 'month',
+              interval_count: 1,
             },
-            quantity: 5, // Business subscription with 5 seats
+            product: {
+              id: 'prod_1ExampleBusiness',
+              object: 'product',
+              active: true,
+              metadata: {
+                type: 'business',
+              },
+              name: 'Business Product',
+            },
           },
-        ],
-      },
-      product: {
-        id: 'prod_1ExampleBusiness',
-        object: 'product',
-        active: true,
-        metadata: {
-          type: 'business',
+          quantity: 5, // Business subscription with 5 seats
         },
-        name: 'Business Product',
-      },
-      current_period_end: Math.floor(Date.now() / 1000) + 2592000, // 30 days from now
-      current_period_start: Math.floor(Date.now() / 1000), // Now
+      ],
     },
-    {
-      id: 'sub_1ExampleEmpty',
-      object: 'subscription',
-      customer: 'cus_987654321',
-      status: 'active',
-      items: {
-        object: 'list',
-        data: [
-          {
-            id: 'si_67890',
-            object: 'subscription_item',
-            price: {
-              id: 'price_1ExampleEmpty',
-              object: 'price',
-              currency: 'usd',
-              unit_amount: 1000,
-              recurring: {
-                interval: 'month',
-                interval_count: 1,
-              },
-              product: {
-                id: 'prod_1ExampleEmpty',
-                object: 'product',
-                active: true,
-                metadata: {}, // Empty metadata
-                name: 'Empty Metadata Product',
-              },
+    product: {
+      id: 'prod_1ExampleBusiness',
+      object: 'product',
+      active: true,
+      metadata: {
+        type: 'business',
+      },
+      name: 'Business Product',
+    },
+    current_period_end: Math.floor(Date.now() / 1000) + 2592000, // 30 days from now
+    current_period_start: Math.floor(Date.now() / 1000), // Now
+  },
+  {
+    id: 'sub_1ExampleEmpty',
+    object: 'subscription',
+    customer: 'cus_987654321',
+    status: 'active',
+    items: {
+      object: 'list',
+      data: [
+        {
+          id: 'si_67890',
+          object: 'subscription_item',
+          price: {
+            id: 'price_1ExampleEmpty',
+            object: 'price',
+            currency: 'usd',
+            unit_amount: 1000,
+            recurring: {
+              interval: 'month',
+              interval_count: 1,
             },
-            quantity: 1, // Default quantity for individual
+            product: {
+              id: 'prod_1ExampleEmpty',
+              object: 'product',
+              active: true,
+              metadata: {}, // Empty metadata
+              name: 'Empty Metadata Product',
+            },
           },
-        ],
-      },
-      product: {
-        id: 'prod_1ExampleEmpty',
-        object: 'product',
-        active: true,
-        metadata: {}, // Empty metadata
-        name: 'Empty Metadata Product',
-      },
-      current_period_end: Math.floor(Date.now() / 1000) + 2592000, // 30 days from now
-      current_period_start: Math.floor(Date.now() / 1000), // Now
+          quantity: 1, // Default quantity for individual
+        },
+      ],
     },
-  ];
+    product: {
+      id: 'prod_1ExampleEmpty',
+      object: 'product',
+      active: true,
+      metadata: {}, // Empty metadata
+      name: 'Empty Metadata Product',
+    },
+    current_period_end: Math.floor(Date.now() / 1000) + 2592000, // 30 days from now
+    current_period_start: Math.floor(Date.now() / 1000), // Now
+  },
+];
 
-  const mockCharge = {
-    id: `ch_${randomUUID()}`,
-    customer: `cus_${randomUUID()}`,
-    invoice: `in_${randomUUID()}`,
-    amount: randomDataGenerator.integer({ min: 500, max: 5000 }),
-    currency: 'usd',
-    status: 'succeeded',
+export const mockedCoupon = () => ({
+  id: randomUUID(),
+  provider: 'stripe',
+  code: 'c0UP0n',
+});
+
+export function getValidToken(userUuid: string): string {
+  return jwt.sign({ payload: { uuid: userUuid } }, envVarsConfig.JWT_SECRET);
+}
+
+export function newTier(params?: Partial<Tier>): Tier {
+  return {
+    billingType: 'subscription',
+    label: 'test-label',
+    productId: randomDataGenerator.string({
+      length: 15,
+    }),
+    featuresPerService: {
+      mail: {
+        enabled: false,
+        addressesPerUser: randomDataGenerator.integer({
+          min: 0,
+          max: 5,
+        }),
+      },
+      meet: {
+        enabled: false,
+        paxPerCall: randomDataGenerator.integer({
+          min: 0,
+          max: 5,
+        }),
+      },
+      vpn: {
+        enabled: false,
+        locationsAvailable: randomDataGenerator.integer({
+          min: 0,
+          max: 5,
+        }),
+      },
+      antivirus: {
+        enabled: false,
+      },
+      backups: {
+        enabled: false,
+      },
+      drive: {
+        enabled: false,
+        maxSpaceBytes: randomDataGenerator.integer({
+          max: 5 * 1024 * 1024 * 1024,
+          min: 1024 * 1024 * 1024,
+        }),
+        workspaces: {
+          enabled: false,
+          maximumSeats: randomDataGenerator.integer({
+            max: 100,
+            min: 10,
+          }),
+          minimumSeats: randomDataGenerator.integer({
+            min: 3,
+            max: 3,
+          }),
+          maxSpaceBytesPerSeat: randomDataGenerator.integer({
+            max: 5 * 1024 * 1024 * 1024,
+            min: 1024 * 1024 * 1024,
+          }),
+        },
+      },
+    },
+    ...params,
   };
+}
 
-  const mockDispute = {
-    id: `dp_${randomUUID()}`,
-    status: 'lost',
-    charge: mockCharge.id,
-    amount: mockCharge.amount,
-    currency: mockCharge.currency,
+export function mockLogger(): jest.Mocked<FastifyBaseLogger> {
+  return {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+    level: 'info',
+    silent: jest.fn(),
+    child: jest.fn(),
   };
+}
 
-  const mockInvoices = [
+export function mockInvoices() {
+  return [
     {
       id: `in_${randomUUID()}`,
       created: 1640995200,
@@ -260,112 +303,84 @@ export default function getMocks() {
       subscription: `sub_${randomUUID()}`,
     },
   ];
+}
 
-  const mockLogger: jest.Mocked<FastifyBaseLogger> = {
-    info: jest.fn(),
-    error: jest.fn(),
-    warn: jest.fn(),
-    debug: jest.fn(),
-    fatal: jest.fn(),
-    trace: jest.fn(),
-    level: 'info',
-    silent: jest.fn(),
-    child: jest.fn(),
-  };
-
-  function getValidToken(userUuid: string): string {
-    return jwt.sign({ payload: { uuid: userUuid } }, envVarsConfig.JWT_SECRET);
-  }
-
-  function newTier(params?: Partial<Tier>): Tier {
-    return {
-      billingType: 'subscription',
-      label: 'test-label',
-      productId: randomDataGenerator.string({
-        length: 15,
-      }),
-      featuresPerService: {
-        mail: {
-          enabled: false,
-          addressesPerUser: randomDataGenerator.integer({
-            min: 0,
-            max: 5,
-          }),
-        },
-        meet: {
-          enabled: false,
-          paxPerCall: randomDataGenerator.integer({
-            min: 0,
-            max: 5,
-          }),
-        },
-        vpn: {
-          enabled: false,
-          locationsAvailable: randomDataGenerator.integer({
-            min: 0,
-            max: 5,
-          }),
-        },
-        antivirus: {
-          enabled: false,
-        },
-        backups: {
-          enabled: false,
-        },
-        drive: {
-          enabled: false,
-          maxSpaceBytes: randomDataGenerator.integer({
-            max: 5 * 1024 * 1024 * 1024,
-            min: 1024 * 1024 * 1024,
-          }),
-          workspaces: {
-            enabled: false,
-            maximumSeats: randomDataGenerator.integer({
-              max: 100,
-              min: 10,
-            }),
-            minimumSeats: randomDataGenerator.integer({
-              min: 3,
-              max: 3,
-            }),
-            maxSpaceBytesPerSeat: randomDataGenerator.integer({
-              max: 5 * 1024 * 1024 * 1024,
-              min: 1024 * 1024 * 1024,
-            }),
-          },
-        },
-      },
-      ...params,
-    };
-  }
-
-  const voidPromise = () => Promise.resolve();
-
+export function uniqueCode() {
   return {
-    user,
-    newUser,
-    preventCancellationTestUsers,
-    uniqueCode,
-    mockedCoupon,
-    mockedUserWithLifetime,
-    mockedUserWithoutLifetime,
-    mockActiveSubscriptions,
-    couponName,
-    mockCharge,
-    mockDispute,
-    mockInvoices,
-    mockLogger,
-    mockedCustomerPayload,
-    createdSubscriptionPayload,
-    paymentIntentResponse,
-    mockCreateSubscriptionResponse,
-    mockPromotionCodeResponse,
-    validToken:
-      // eslint-disable-next-line max-len
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp7InV1aWQiOiJiODQyODk3YS01MDg2LTQxODMtYWZiMS1mYTAwNGVlMzljNjYiLCJlbWFpbCI6InByZXBheW1lbnRzbGF1bmNoQGlueHQuY29tIiwibmFtZSI6ImhlbGxvIiwibGFzdG5hbWUiOiJoZWxsbyIsInVzZXJuYW1lIjoicHJlcGF5bWVudHNsYXVuY2hAaW54dC5jb20iLCJzaGFyZWRXb3Jrc3BhY2UiOnRydWUsIm5ldHdvcmtDcmVkZW50aWFscyI6eyJ1c2VyIjoicHJlcGF5bWVudHNsYXVuY2hAaW54dC5jb20iLCJwYXNzIjoiJDJhJDA4JFRRSmppNS9wUHpWUlp0UWNxOW9hd3VsdEFUYUlMTjdlUHNjWHg2Vy95WDhzNGJyM1FtOWJtIn19LCJpYXQiOjE2NTUxMDQwOTZ9.s3791sv4gmWgt5Ni1a8DnRw_5JyJ8g9Ff0bpIlqo6LM',
-    prices,
-    getValidToken,
-    voidPromise,
-    newTier,
+    techCult: {
+      codes: {
+        elegible: '5tb_redeem_code', //REDEEMED: FALSE
+        nonElegible: '2tb_code_redeem', //REDEEMED: TRUE
+        doesntExist: 'doesnt_exist',
+      },
+      provider: 'TECHCULT',
+    },
+    stackCommerce: {
+      codes: {
+        elegible: '5tb_redeem_code', //REDEEMED: FALSE
+        nonElegible: '2tb_code_redeem', //REDEEMED: TRUE
+        doesntExist: 'doesnt_exist',
+      },
+      provider: 'STACKCOMMERCE',
+    },
   };
 }
+
+export function preventCancellationTestUsers() {
+  return {
+    nonElegible: {
+      lifetimeUserUuid: 'ee4f8abf-397c-4558-b794-a675a4bed2d7',
+      subscriptionUserUuid: '48cef034-011b-4e75-9671-86928a2370e7',
+    },
+    elegible: {
+      subscriptionUserUuid: '223b88d7-f5a0-4592-a76c-22758c074757',
+    },
+  };
+}
+
+export function mockedUserWithLifetime(): User {
+  return {
+    id: randomUUID(),
+    uuid: randomUUID(),
+    customerId: `cus_${randomUUID()}`,
+    lifetime: true,
+  };
+}
+
+export function mockCharge() {
+  return {
+    id: `ch_${randomDataGenerator.string({
+      length: 8,
+    })}`,
+    customer: `cus_${randomDataGenerator.string({
+      length: 8,
+    })}`,
+    invoice: `in_${randomDataGenerator.string({
+      length: 8,
+    })}`,
+    amount: randomDataGenerator.integer({ min: 500, max: 5000 }),
+    currency: 'usd',
+    status: 'succeeded',
+  };
+}
+
+export function mockDispute(mockedCharge: {
+  id: string;
+  customer: string;
+  invoice: string;
+  amount: number;
+  currency: string;
+  status: string;
+}) {
+  return {
+    id: `dp_${randomDataGenerator.string({
+      length: 8,
+    })}`,
+    status: 'lost',
+    charge: mockedCharge.id,
+    amount: mockedCharge.amount,
+    currency: mockedCharge.currency,
+  };
+}
+
+export const voidPromise = () => Promise.resolve();

--- a/tests/src/payments.controller.test.ts
+++ b/tests/src/payments.controller.test.ts
@@ -6,7 +6,6 @@ import axios from 'axios';
 
 import { default as start } from '../../src/server';
 
-import getMocks from './mocks';
 import { preloadData } from './utils/preloadMongoDBData';
 import { UserNotFoundError, UsersService } from '../../src/services/users.service';
 import { Bit2MeService } from '../../src/services/bit2me.service';
@@ -20,8 +19,7 @@ import { InvalidTaxIdError, PaymentService } from '../../src/services/payment.se
 import testFactory from './utils/factory';
 import config from '../../src/config';
 import { User } from '../../src/core/users/User';
-
-const mocks = getMocks();
+import { getValidToken, prices, uniqueCode, user } from './mocks';
 
 let mongoServer: MongoMemoryServer;
 let mongoClient: MongoClient;
@@ -100,10 +98,9 @@ afterAll(async () => {
 describe('Payment controller e2e tests', () => {
   describe('Check if the unique code provided by the user is valid', () => {
     it('When the code is already used, then it returns 404 status code', async () => {
-      const { uniqueCode } = mocks;
       const response = await app.inject({
         path: '/is-unique-code-available',
-        query: { code: uniqueCode.techCult.codes.nonElegible, provider: uniqueCode.techCult.provider },
+        query: { code: uniqueCode().techCult.codes.nonElegible, provider: uniqueCode().techCult.provider },
         method: 'GET',
       });
       expect(response.statusCode).toBe(404);
@@ -111,11 +108,9 @@ describe('Payment controller e2e tests', () => {
 
     // eslint-disable-next-line quotes
     it("When the code doesn't exist, then it returns 404 status code", async () => {
-      const { uniqueCode } = mocks;
-
       const response = await app.inject({
         path: '/is-unique-code-available',
-        query: { code: uniqueCode.techCult.codes.doesntExist, provider: uniqueCode.techCult.provider },
+        query: { code: uniqueCode().techCult.codes.doesntExist, provider: uniqueCode().techCult.provider },
         method: 'GET',
       });
 
@@ -126,7 +121,6 @@ describe('Payment controller e2e tests', () => {
   describe('Fetching plan object by ID and contains the basic params', () => {
     describe('Fetch subscription plan object', () => {
       it('When the subscription priceId is valid, then the endpoint returns the correct object', async () => {
-        const { prices } = mocks;
         const expectedKeys = {
           selectedPlan: {
             id: expect.anything(),
@@ -147,7 +141,7 @@ describe('Payment controller e2e tests', () => {
         };
 
         const response = await app.inject({
-          path: `/plan-by-id?planId=${prices.subscription.exists}`,
+          path: `/plan-by-id?planId=${prices().subscription.exists}`,
           method: 'GET',
         });
         const responseBody = JSON.parse(response.body);
@@ -157,10 +151,8 @@ describe('Payment controller e2e tests', () => {
       });
 
       it('When the subscription priceId is not valid, then it returns 404 status code', async () => {
-        const { prices } = mocks;
-
         const response = await app.inject({
-          path: `/plan-by-id?planId=${prices.subscription.doesNotExist}`,
+          path: `/plan-by-id?planId=${prices().subscription.doesNotExist}`,
           method: 'GET',
         });
 
@@ -170,8 +162,6 @@ describe('Payment controller e2e tests', () => {
 
     describe('Fetch Lifetime plan object', () => {
       it('When the lifetime priceId is valid, then it returns the lifetime price object', async () => {
-        const { prices } = mocks;
-
         const expectedKeys = {
           selectedPlan: {
             id: expect.anything(),
@@ -184,7 +174,7 @@ describe('Payment controller e2e tests', () => {
         };
 
         const response = await app.inject({
-          path: `/plan-by-id?planId=${prices.lifetime.exists}`,
+          path: `/plan-by-id?planId=${prices().lifetime.exists}`,
           method: 'GET',
         });
 
@@ -195,10 +185,8 @@ describe('Payment controller e2e tests', () => {
       });
 
       it('When the lifetime priceId is not valid, then returns 404 status code', async () => {
-        const { prices } = mocks;
-
         const response = await app.inject({
-          path: `/plan-by-id?planId=${prices.lifetime.doesNotExist}`,
+          path: `/plan-by-id?planId=${prices().lifetime.doesNotExist}`,
           method: 'GET',
         });
 
@@ -212,8 +200,7 @@ describe('Payment controller e2e tests', () => {
       jest.restoreAllMocks();
     });
 
-    const { user, getValidToken } = mocks;
-    const createdToken = getValidToken(user.uuid);
+    const createdToken = getValidToken(user().uuid);
     const authToken = `Bearer ${createdToken}`;
 
     it('When the email is missing in the request body, then it returns a 400 status code', async () => {
@@ -229,7 +216,9 @@ describe('Payment controller e2e tests', () => {
     });
 
     it('When the user exists by UUID, then it returns the customerId and a token', async () => {
-      jest.spyOn(UsersService.prototype, 'findUserByUuid').mockResolvedValue(Promise.resolve(user as unknown as User));
+      jest
+        .spyOn(UsersService.prototype, 'findUserByUuid')
+        .mockResolvedValue(Promise.resolve(user() as unknown as User));
 
       const response = await app.inject({
         path: `/create-customer`,
@@ -243,7 +232,7 @@ describe('Payment controller e2e tests', () => {
 
       const responseBody = JSON.parse(response.body);
       expect(responseBody).toEqual({
-        customerId: user.customerId,
+        customerId: user().customerId,
         token: expect.any(String),
       });
     });
@@ -270,7 +259,7 @@ describe('Payment controller e2e tests', () => {
       jest.spyOn(UsersService.prototype, 'findUserByUuid').mockRejectedValue(userNotFoundError);
       const createOrGetCustomerSpy = jest
         .spyOn(PaymentService.prototype, 'createOrGetCustomer')
-        .mockResolvedValue({ id: user.customerId } as unknown as Stripe.Customer);
+        .mockResolvedValue({ id: user().customerId } as unknown as Stripe.Customer);
 
       await app.inject({
         path: `/create-customer`,
@@ -290,7 +279,7 @@ describe('Payment controller e2e tests', () => {
       jest.spyOn(UsersService.prototype, 'findUserByUuid').mockRejectedValue(userNotFoundError);
       const createOrGetCustomerSpy = jest
         .spyOn(PaymentService.prototype, 'createOrGetCustomer')
-        .mockResolvedValue({ id: user.customerId } as unknown as Stripe.Customer);
+        .mockResolvedValue({ id: user().customerId } as unknown as Stripe.Customer);
 
       const response = await app.inject({
         path: `/create-customer`,
@@ -305,7 +294,7 @@ describe('Payment controller e2e tests', () => {
       expect(createOrGetCustomerSpy).toHaveBeenCalledTimes(1);
       expect(response.statusCode).toBe(200);
       expect(JSON.parse(response.body)).toEqual({
-        customerId: user.customerId,
+        customerId: user().customerId,
         token: expect.any(String),
       });
     });

--- a/tests/src/services/tiers.service.test.ts
+++ b/tests/src/services/tiers.service.test.ts
@@ -3,7 +3,6 @@ import Stripe from 'stripe';
 
 import testFactory from '../utils/factory';
 import config from '../../../src/config';
-import getMocks from '../mocks';
 import {
   ALLOWED_PRODUCT_IDS_FOR_ANTIVIRUS,
   TierNotFoundError,
@@ -24,6 +23,7 @@ import { CouponsRepository } from '../../../src/core/coupons/CouponsRepository';
 import { UsersCouponsRepository } from '../../../src/core/coupons/UsersCouponsRepository';
 import { ProductsRepository } from '../../../src/core/users/ProductsRepository';
 import { Bit2MeService } from '../../../src/services/bit2me.service';
+import { mockedUserWithLifetime, newTier } from '../mocks';
 
 let tiersService: TiersService;
 let paymentsService: PaymentService;
@@ -36,7 +36,6 @@ let couponsRepository: CouponsRepository;
 let usersCouponsRepository: UsersCouponsRepository;
 let productsRepository: ProductsRepository;
 let bit2MeService: Bit2MeService;
-const mocks = getMocks();
 
 jest
   .spyOn(require('../../../src/services/storage.service'), 'createOrUpdateUser')
@@ -79,7 +78,7 @@ describe('TiersService tests', () => {
 
   describe('getAntivirusTier()', () => {
     it('When the user has a valid active subscription, then returns antivirus enabled', async () => {
-      const customerId: CustomerId = mocks.mockedUserWithLifetime.customerId;
+      const customerId: CustomerId = mockedUserWithLifetime().customerId;
       const activeSubscription = { status: 'active', product: { id: ALLOWED_PRODUCT_IDS_FOR_ANTIVIRUS[0] } };
 
       jest
@@ -94,7 +93,7 @@ describe('TiersService tests', () => {
     });
 
     it('When the user has an active subscription but is not eligible for antivirus, then returns antivirus disabled', async () => {
-      const customerId: CustomerId = mocks.mockedUserWithLifetime.customerId;
+      const customerId: CustomerId = mockedUserWithLifetime().customerId;
       const activeSubscription = { status: 'active', product: { id: 'some_other_product' } };
 
       jest
@@ -109,7 +108,7 @@ describe('TiersService tests', () => {
     });
 
     it('When the user has no active subscription but has a valid lifetime product, then returns antivirus enabled', async () => {
-      const customerId: CustomerId = mocks.mockedUserWithLifetime.customerId;
+      const customerId: CustomerId = mockedUserWithLifetime().customerId;
       const isLifetime = true;
 
       jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([]);
@@ -127,7 +126,7 @@ describe('TiersService tests', () => {
     });
 
     it('When the user has no active subscription and is not lifetime, then throws NotFoundSubscriptionError', async () => {
-      const customerId: CustomerId = mocks.mockedUserWithLifetime.customerId;
+      const customerId: CustomerId = mockedUserWithLifetime().customerId;
 
       jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([]);
 
@@ -137,7 +136,7 @@ describe('TiersService tests', () => {
     });
 
     it('When the user is lifetime but the product is not in the allowed list, then returns antivirus disabled', async () => {
-      const customerId: CustomerId = mocks.mockedUserWithLifetime.customerId;
+      const customerId: CustomerId = mockedUserWithLifetime().customerId;
       const isLifetime = true;
 
       jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([]);
@@ -153,7 +152,7 @@ describe('TiersService tests', () => {
     });
 
     it('When the user has both an active subscription and a valid lifetime product, then returns antivirus enabled', async () => {
-      const customerId: CustomerId = mocks.mockedUserWithLifetime.customerId;
+      const customerId: CustomerId = mockedUserWithLifetime().customerId;
       const isLifetime = true;
       const activeSubscription = { status: 'active', product: { id: ALLOWED_PRODUCT_IDS_FOR_ANTIVIRUS[0] } };
 
@@ -176,7 +175,7 @@ describe('TiersService tests', () => {
 
   describe('applyTier()', () => {
     it('When applying the tier, then fails if the tier is not found', async () => {
-      const user = mocks.mockedUserWithLifetime;
+      const user = mockedUserWithLifetime();
       const productId = 'productId';
 
       const findTierByProductId = jest
@@ -191,8 +190,8 @@ describe('TiersService tests', () => {
     });
 
     it('When applying the tier, then skips disabled features', async () => {
-      const user = mocks.mockedUserWithLifetime;
-      const tier = mocks.newTier();
+      const user = mockedUserWithLifetime();
+      const tier = newTier();
       const { productId } = tier;
       tier.featuresPerService[Service.Drive].enabled = false;
       tier.featuresPerService[Service.Vpn].enabled = false;
@@ -213,8 +212,8 @@ describe('TiersService tests', () => {
     });
 
     it('When applying the tier, then applies enabled features', async () => {
-      const user = mocks.mockedUserWithLifetime;
-      const tier = mocks.newTier();
+      const user = mockedUserWithLifetime();
+      const tier = newTier();
       const userWithEmail = { ...user, email: 'fake email' };
       const { productId } = tier;
       tier.featuresPerService[Service.Drive].enabled = true;
@@ -238,8 +237,8 @@ describe('TiersService tests', () => {
 
   describe('applyDriveFeatures()', () => {
     it('When workspaces is enabled, then it is applied exclusively', async () => {
-      const userWithEmail = { ...mocks.mockedUserWithLifetime, email: 'test@internxt.com' };
-      const tier = mocks.newTier();
+      const userWithEmail = { ...mockedUserWithLifetime(), email: 'test@internxt.com' };
+      const tier = newTier();
 
       tier.featuresPerService[Service.Drive].enabled = true;
       tier.featuresPerService[Service.Drive].workspaces.enabled = true;
@@ -262,8 +261,8 @@ describe('TiersService tests', () => {
     });
 
     it('When workspaces is enabled and the workspace do not exist, then it is initialized', async () => {
-      const userWithEmail = { ...mocks.mockedUserWithLifetime, email: 'test@internxt.com' };
-      const tier = mocks.newTier();
+      const userWithEmail = { ...mockedUserWithLifetime(), email: 'test@internxt.com' };
+      const tier = newTier();
 
       tier.featuresPerService[Service.Drive].enabled = true;
       tier.featuresPerService[Service.Drive].workspaces.enabled = true;
@@ -286,8 +285,8 @@ describe('TiersService tests', () => {
     });
 
     it('When workspaces is not enabled, then individual is initialized', async () => {
-      const userWithEmail = { ...mocks.mockedUserWithLifetime, email: 'test@internxt.com' };
-      const tier = mocks.newTier();
+      const userWithEmail = { ...mockedUserWithLifetime(), email: 'test@internxt.com' };
+      const tier = newTier();
 
       tier.featuresPerService[Service.Drive].enabled = true;
       tier.featuresPerService[Service.Drive].workspaces.enabled = false;
@@ -305,8 +304,8 @@ describe('TiersService tests', () => {
 
   describe('applyVpnFeatures()', () => {
     it('When it is called, then it does not throw', async () => {
-      const userWithEmail = { ...mocks.mockedUserWithLifetime, email: 'test@internxt.com' };
-      const tier = mocks.newTier();
+      const userWithEmail = { ...mockedUserWithLifetime(), email: 'test@internxt.com' };
+      const tier = newTier();
 
       tier.featuresPerService[Service.Vpn].enabled = true;
 

--- a/tests/src/services/users.service.test.ts
+++ b/tests/src/services/users.service.test.ts
@@ -12,8 +12,8 @@ import { UsersCouponsRepository } from '../../../src/core/coupons/UsersCouponsRe
 import { ProductsRepository } from '../../../src/core/users/ProductsRepository';
 import { FREE_PLAN_BYTES_SPACE } from '../../../src/constants';
 import testFactory from '../utils/factory';
-import getMocks from '../mocks';
 import { Bit2MeService } from '../../../src/services/bit2me.service';
+import { couponName, mockActiveSubscriptions, mockedCoupon, mockedUserWithoutLifetime } from '../mocks';
 
 let paymentService: PaymentService;
 let storageService: StorageService;
@@ -52,8 +52,6 @@ beforeEach(() => {
 
 const voidPromise = () => Promise.resolve();
 
-const mocks = getMocks();
-
 describe('UsersService tests', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -61,16 +59,17 @@ describe('UsersService tests', () => {
 
   describe('Insert User in Mongo DB', () => {
     it('When trying to add a user with the correct params, the user is inserted successfully', async () => {
+      const mockedUser = mockedUserWithoutLifetime();
       await usersService.insertUser({
-        customerId: mocks.mockedUserWithoutLifetime.customerId,
-        uuid: mocks.mockedUserWithoutLifetime.uuid,
+        customerId: mockedUser.customerId,
+        uuid: mockedUser.uuid,
         lifetime: true,
       });
 
       expect(usersRepository.insertUser).toHaveBeenCalledTimes(1);
       expect(usersRepository.insertUser).toHaveBeenCalledWith({
-        customerId: mocks.mockedUserWithoutLifetime.customerId,
-        uuid: mocks.mockedUserWithoutLifetime.uuid,
+        customerId: mockedUser.customerId,
+        uuid: mockedUser.uuid,
         lifetime: true,
       });
     });
@@ -78,58 +77,61 @@ describe('UsersService tests', () => {
 
   describe('Find customer by Customer ID', () => {
     it('When looking for a customer by its ID with the correct params, then the customer is found', async () => {
-      (usersRepository.findUserByCustomerId as jest.Mock).mockResolvedValue(mocks.mockedUserWithoutLifetime);
+      const mockedUser = mockedUserWithoutLifetime();
+      (usersRepository.findUserByCustomerId as jest.Mock).mockResolvedValue(mockedUser);
 
-      const result = await usersService.findUserByCustomerID(mocks.mockedUserWithoutLifetime.customerId);
+      const result = await usersService.findUserByCustomerID(mockedUser.customerId);
 
-      expect(result).toStrictEqual(mocks.mockedUserWithoutLifetime);
+      expect(result).toStrictEqual(mockedUser);
       expect(usersRepository.findUserByCustomerId).toHaveBeenCalledTimes(1);
-      expect(usersRepository.findUserByCustomerId).toHaveBeenCalledWith(mocks.mockedUserWithoutLifetime.customerId);
+      expect(usersRepository.findUserByCustomerId).toHaveBeenCalledWith(mockedUser.customerId);
     });
 
     it('when no user is found by customerId, then an UserNotFoundError is thrown', async () => {
+      const mockedUser = mockedUserWithoutLifetime();
+
       (usersRepository.findUserByCustomerId as jest.Mock).mockResolvedValue(null);
 
-      await expect(usersService.findUserByCustomerID(mocks.mockedUserWithoutLifetime.customerId)).rejects.toThrow(
-        UserNotFoundError,
-      );
+      await expect(usersService.findUserByCustomerID(mockedUser.customerId)).rejects.toThrow(UserNotFoundError);
 
       expect(usersRepository.findUserByCustomerId).toHaveBeenCalledTimes(1);
-      expect(usersRepository.findUserByCustomerId).toHaveBeenCalledWith(mocks.mockedUserWithoutLifetime.customerId);
+      expect(usersRepository.findUserByCustomerId).toHaveBeenCalledWith(mockedUser.customerId);
     });
   });
 
   describe('Find customer by User UUId', () => {
     it('When looking for a customer by UUID with the correct params, then the customer is found', async () => {
-      (usersRepository.findUserByUuid as jest.Mock).mockResolvedValue(mocks.mockedUserWithoutLifetime);
+      const mockedUser = mockedUserWithoutLifetime();
+      (usersRepository.findUserByUuid as jest.Mock).mockResolvedValue(mockedUser);
 
-      const result = await usersService.findUserByUuid(mocks.mockedUserWithoutLifetime.uuid);
+      const result = await usersService.findUserByUuid(mockedUser.uuid);
 
-      expect(result).toStrictEqual(mocks.mockedUserWithoutLifetime);
+      expect(result).toStrictEqual(mockedUser);
       expect(usersRepository.findUserByUuid).toHaveBeenCalledTimes(1);
-      expect(usersRepository.findUserByUuid).toHaveBeenCalledWith(mocks.mockedUserWithoutLifetime.uuid);
+      expect(usersRepository.findUserByUuid).toHaveBeenCalledWith(mockedUser.uuid);
     });
 
     it('when no user is found by UUID then should throw UserNotFoundError', async () => {
+      const mockedUser = mockedUserWithoutLifetime();
       (usersRepository.findUserByUuid as jest.Mock).mockResolvedValue(null);
 
-      await expect(usersService.findUserByUuid(mocks.mockedUserWithoutLifetime.uuid)).rejects.toThrow(
-        UserNotFoundError,
-      );
+      await expect(usersService.findUserByUuid(mockedUser.uuid)).rejects.toThrow(UserNotFoundError);
 
       expect(usersRepository.findUserByUuid).toHaveBeenCalledTimes(1);
-      expect(usersRepository.findUserByUuid).toHaveBeenCalledWith(mocks.mockedUserWithoutLifetime.uuid);
+      expect(usersRepository.findUserByUuid).toHaveBeenCalledWith(mockedUser.uuid);
     });
   });
 
   describe('Cancelling user subscription', () => {
     describe('Cancel the user individual subscription', () => {
       it('When the customer wants to cancel the individual subscription, then the Stripe plan is cancelled and the storage is restored', async () => {
+        const mockedUser = mockedUserWithoutLifetime();
+        const mockedActiveSubscriptions = mockActiveSubscriptions();
         jest
           .spyOn(paymentService, 'getActiveSubscriptions')
           .mockImplementation(() =>
             Promise.resolve(
-              mocks.mockActiveSubscriptions.filter(
+              mockedActiveSubscriptions.filter(
                 (sub) => sub.product?.metadata.type !== 'business',
               ) as unknown as ExtendedSubscription[],
             ),
@@ -137,37 +139,35 @@ describe('UsersService tests', () => {
         const cancelSubscriptionSpy = jest.spyOn(paymentService, 'cancelSubscription').mockImplementation(voidPromise);
         const changeStorageSpy = jest.spyOn(storageService, 'changeStorage').mockImplementation(voidPromise);
 
-        await usersService.cancelUserIndividualSubscriptions(mocks.mockedUserWithoutLifetime.customerId);
-        await storageService.changeStorage(mocks.mockedUserWithoutLifetime.uuid, FREE_PLAN_BYTES_SPACE);
+        await usersService.cancelUserIndividualSubscriptions(mockedUser.customerId);
+        await storageService.changeStorage(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
 
-        const individualSubscriptions = mocks.mockActiveSubscriptions.filter(
+        const individualSubscriptions = mockedActiveSubscriptions.filter(
           (sub) => sub.product?.metadata.type !== 'business',
         );
         expect(cancelSubscriptionSpy).toHaveBeenCalledTimes(individualSubscriptions.length);
 
         expect(changeStorageSpy).toHaveBeenCalledTimes(1);
-        expect(changeStorageSpy).toHaveBeenCalledWith(mocks.mockedUserWithoutLifetime.uuid, FREE_PLAN_BYTES_SPACE);
+        expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
       });
     });
 
     describe('Cancel the user B2B subscription', () => {
       it('When the customer wants to cancel the individual subscription, then the Stripe plans are cancelled', async () => {
+        const mockedUser = mockedUserWithoutLifetime();
+        const mockedActiveSubscriptions = mockActiveSubscriptions();
         jest
           .spyOn(paymentService, 'getActiveSubscriptions')
-          .mockImplementation(() =>
-            Promise.resolve(mocks.mockActiveSubscriptions as unknown as ExtendedSubscription[]),
-          );
+          .mockImplementation(() => Promise.resolve(mockedActiveSubscriptions as unknown as ExtendedSubscription[]));
 
         const cancelSubscriptionSpy = jest.spyOn(paymentService, 'cancelSubscription').mockImplementation(voidPromise);
 
         const changeStorageSpy = jest.spyOn(storageService, 'changeStorage').mockImplementation(voidPromise);
 
-        await usersService.cancelUserB2BSuscriptions(mocks.mockedUserWithoutLifetime.customerId);
-        await storageService.changeStorage(mocks.mockedUserWithoutLifetime.uuid, FREE_PLAN_BYTES_SPACE);
+        await usersService.cancelUserB2BSuscriptions(mockedUser.customerId);
+        await storageService.changeStorage(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
 
-        const b2bSubscriptions = mocks.mockActiveSubscriptions.filter(
-          (sub) => sub.product?.metadata.type === 'business',
-        );
+        const b2bSubscriptions = mockedActiveSubscriptions.filter((sub) => sub.product?.metadata.type === 'business');
 
         expect(cancelSubscriptionSpy).toHaveBeenCalledTimes(b2bSubscriptions.length);
 
@@ -176,80 +176,80 @@ describe('UsersService tests', () => {
         });
 
         expect(changeStorageSpy).toHaveBeenCalledTimes(1);
-        expect(changeStorageSpy).toHaveBeenCalledWith(mocks.mockedUserWithoutLifetime.uuid, FREE_PLAN_BYTES_SPACE);
+        expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
       });
     });
   });
 
   describe('Storing coupon user by user', () => {
     it('When the coupon is tracked, then the coupon is stored correctly', async () => {
-      (couponsRepository.findByCode as jest.Mock).mockResolvedValue(mocks.mockedCoupon);
+      const coupon = mockedCoupon();
+      const mockedUser = mockedUserWithoutLifetime();
 
-      await usersService.storeCouponUsedByUser(mocks.mockedUserWithoutLifetime, mocks.mockedCoupon.code);
+      (couponsRepository.findByCode as jest.Mock).mockResolvedValue(coupon);
 
-      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mocks.mockedCoupon.code);
+      await usersService.storeCouponUsedByUser(mockedUser, coupon.code);
+
+      expect(couponsRepository.findByCode).toHaveBeenCalledWith(coupon.code);
       expect(usersCouponsRepository.create).toHaveBeenCalledWith({
-        coupon: mocks.mockedCoupon.id,
-        user: mocks.mockedUserWithoutLifetime.id,
+        coupon: coupon.id,
+        user: mockedUser.id,
       });
     });
 
     it('when the coupon is not tracked, then the an CouponNotBeingTrackedError is thrown', async () => {
+      const mockedCouponName = couponName();
+      const mockedUser = mockedUserWithoutLifetime();
+
       (couponsRepository.findByCode as jest.Mock).mockResolvedValue(null);
 
-      await expect(
-        usersService.storeCouponUsedByUser(mocks.mockedUserWithoutLifetime, mocks.couponName.invalid),
-      ).rejects.toThrow(CouponNotBeingTrackedError);
+      await expect(usersService.storeCouponUsedByUser(mockedUser, mockedCouponName.invalid)).rejects.toThrow(
+        CouponNotBeingTrackedError,
+      );
 
-      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mocks.couponName.invalid);
+      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mockedCouponName.invalid);
       expect(usersCouponsRepository.create).not.toHaveBeenCalled();
     });
   });
 
   describe('isCouponBeingUsedByUser', () => {
     it('When the coupon is tracked and used by the user, then returns true', async () => {
-      (couponsRepository.findByCode as jest.Mock).mockResolvedValue(mocks.mockedCoupon);
+      const mockedUser = mockedUserWithoutLifetime();
+      const coupon = mockedCoupon();
+
+      (couponsRepository.findByCode as jest.Mock).mockResolvedValue(coupon);
       (usersCouponsRepository.findByUserAndCoupon as jest.Mock).mockResolvedValue({ id: 'entry1' });
 
-      const result = await usersService.isCouponBeingUsedByUser(
-        mocks.mockedUserWithoutLifetime,
-        mocks.mockedCoupon.code,
-      );
+      const result = await usersService.isCouponBeingUsedByUser(mockedUser, coupon.code);
 
-      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mocks.mockedCoupon.code);
-      expect(usersCouponsRepository.findByUserAndCoupon).toHaveBeenCalledWith(
-        mocks.mockedUserWithoutLifetime.id,
-        mocks.mockedCoupon.id,
-      );
+      expect(couponsRepository.findByCode).toHaveBeenCalledWith(coupon.code);
+      expect(usersCouponsRepository.findByUserAndCoupon).toHaveBeenCalledWith(mockedUser.id, coupon.id);
       expect(result).toBe(true);
     });
 
     it('When the coupon is tracked but not used by the user, then returns false', async () => {
-      (couponsRepository.findByCode as jest.Mock).mockResolvedValue(mocks.mockedCoupon);
+      const mockedUser = mockedUserWithoutLifetime();
+      const coupon = mockedCoupon();
+
+      (couponsRepository.findByCode as jest.Mock).mockResolvedValue(coupon);
       (usersCouponsRepository.findByUserAndCoupon as jest.Mock).mockResolvedValue(null);
 
-      const result = await usersService.isCouponBeingUsedByUser(
-        mocks.mockedUserWithoutLifetime,
-        mocks.mockedCoupon.code,
-      );
+      const result = await usersService.isCouponBeingUsedByUser(mockedUser, coupon.code);
 
-      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mocks.mockedCoupon.code);
-      expect(usersCouponsRepository.findByUserAndCoupon).toHaveBeenCalledWith(
-        mocks.mockedUserWithoutLifetime.id,
-        mocks.mockedCoupon.id,
-      );
+      expect(couponsRepository.findByCode).toHaveBeenCalledWith(coupon.code);
+      expect(usersCouponsRepository.findByUserAndCoupon).toHaveBeenCalledWith(mockedUser.id, coupon.id);
       expect(result).toBe(false);
     });
 
     it('When the coupon is not tracked, then returns false', async () => {
+      const mockedUser = mockedUserWithoutLifetime();
+      const mockedCouponName = couponName();
+
       (couponsRepository.findByCode as jest.Mock).mockResolvedValue(null);
 
-      const result = await usersService.isCouponBeingUsedByUser(
-        mocks.mockedUserWithoutLifetime,
-        mocks.couponName.invalid,
-      );
+      const result = await usersService.isCouponBeingUsedByUser(mockedUser, mockedCouponName.invalid);
 
-      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mocks.couponName.invalid);
+      expect(couponsRepository.findByCode).toHaveBeenCalledWith(mockedCouponName.invalid);
       expect(usersCouponsRepository.findByUserAndCoupon).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });

--- a/tests/src/utils/preloadMongoDBData.ts
+++ b/tests/src/utils/preloadMongoDBData.ts
@@ -1,43 +1,45 @@
 import { MongoClient } from 'mongodb';
-import getMocks from '../mocks';
 import { UserType } from '../../../src/core/users/User';
+import { prices, uniqueCode, user } from '../mocks';
 
 export const preloadData = async (client: MongoClient) => {
-  const mocks = getMocks();
+  const mockedUser = user();
+  const mockedPrices = prices();
+  const mockedUniqueCode = uniqueCode();
   const db = client.db('payments');
 
   await db.collection('license_codes').insertMany([
     {
-      priceId: mocks.prices.lifetime.exists,
-      provider: mocks.uniqueCode.techCult.provider,
-      code: mocks.uniqueCode.techCult.codes.elegible,
+      priceId: mockedPrices.lifetime.exists,
+      provider: mockedUniqueCode.techCult.provider,
+      code: mockedUniqueCode.techCult.codes.elegible,
       redeemed: false,
     },
     {
-      priceId: mocks.prices.lifetime.exists,
-      provider: mocks.uniqueCode.techCult.provider,
-      code: mocks.uniqueCode.techCult.codes.nonElegible,
+      priceId: mockedPrices.lifetime.exists,
+      provider: mockedUniqueCode.techCult.provider,
+      code: mockedUniqueCode.techCult.codes.nonElegible,
       redeemed: true,
     },
     {
-      priceId: mocks.prices.lifetime.exists,
-      provider: mocks.uniqueCode.stackCommerce.provider,
-      code: mocks.uniqueCode.stackCommerce.codes.elegible,
+      priceId: mockedPrices.lifetime.exists,
+      provider: mockedUniqueCode.stackCommerce.provider,
+      code: mockedUniqueCode.stackCommerce.codes.elegible,
       redeemed: false,
     },
     {
-      priceId: mocks.prices.lifetime.exists,
-      provider: mocks.uniqueCode.stackCommerce.provider,
-      code: mocks.uniqueCode.stackCommerce.codes.nonElegible,
+      priceId: mockedPrices.lifetime.exists,
+      provider: mockedUniqueCode.stackCommerce.provider,
+      code: mockedUniqueCode.stackCommerce.codes.nonElegible,
       redeemed: true,
     },
   ]);
 
   await db.collection('users').insertMany([
     {
-      customer_id: mocks.user.customerId,
-      uuid: mocks.user.uuid,
-      lifetime: mocks.user.lifetime,
+      customer_id: mockedUser.customerId,
+      uuid: mockedUser.uuid,
+      lifetime: mockedUser.lifetime,
     },
   ]);
 

--- a/tests/src/webhooks/handleDisputeResult.test.ts
+++ b/tests/src/webhooks/handleDisputeResult.test.ts
@@ -40,7 +40,7 @@ jest.mock('stripe', () => {
         retrieve: jest.fn(),
       },
       subscriptions: {
-        cancel: jest.fn(), // <-- ¡agrega esto!
+        cancel: jest.fn(),
       },
     })),
   };

--- a/tests/src/webhooks/handleInvoiceCompleted.test.ts
+++ b/tests/src/webhooks/handleInvoiceCompleted.test.ts
@@ -3,7 +3,6 @@ import axios from 'axios';
 import { ProductsRepository } from '../../../src/core/users/ProductsRepository';
 import { Bit2MeService } from '../../../src/services/bit2me.service';
 import { ExtendedSubscription, PaymentService } from '../../../src/services/payment.service';
-import getMocks from '../mocks';
 import testFactory from '../utils/factory';
 import { UserNotFoundError, UsersService } from '../../../src/services/users.service';
 import { DisplayBillingRepository } from '../../../src/core/users/MongoDBDisplayBillingRepository';
@@ -16,8 +15,7 @@ import CacheService from '../../../src/services/cache.service';
 import handleInvoiceCompleted from '../../../src/webhooks/handleInvoiceCompleted';
 import { ObjectStorageService } from '../../../src/services/objectStorage.service';
 import { User } from '../../../src/core/users/User';
-
-const { user, newUser, mockLogger } = getMocks();
+import { mockLogger, user } from '../mocks';
 
 jest.mock('../../../src/services/storage.service', () => {
   const actualModule = jest.requireActual('../../../src/services/storage.service');
@@ -98,7 +96,10 @@ describe('Process when an invoice payment is completed', () => {
 
     objectStorageService = new ObjectStorageService(paymentService, config, axios);
 
-    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue({ deleted: false, customer: user.customerId } as any);
+    const mockedUser = user();
+    jest
+      .spyOn(paymentService, 'getCustomer')
+      .mockResolvedValue({ deleted: false, customer: mockedUser.customerId } as any);
     jest.spyOn(paymentService, 'getInvoiceLineItems').mockResolvedValue({
       data: [
         {
@@ -112,209 +113,78 @@ describe('Process when an invoice payment is completed', () => {
       ],
     } as any);
     jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([] as ExtendedSubscription[]);
-    (createOrUpdateUser as jest.Mock).mockResolvedValue(Promise.resolve({ data: { user } }));
+    (createOrUpdateUser as jest.Mock).mockResolvedValue(Promise.resolve({ data: { user: { ...mockedUser } } }));
     (updateUserTier as jest.Mock).mockResolvedValue(Promise.resolve());
 
     jest.clearAllMocks();
   });
 
-  describe('User update', () => {
-    it('When the user exists, then update their information as needed', async () => {
-      jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(user as User);
-      jest.spyOn(usersRepository, 'updateUser');
+  it('When user exists, then the user is updated if needed in the DB', async () => {
+    const mockedUser = user();
+    jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser as User);
+    jest.spyOn(usersRepository, 'updateUser');
 
-      await handleInvoiceCompleted(
-        fakeInvoiceCompletedSession,
-        usersService,
-        paymentService,
-        mockLogger,
-        cacheService,
-        config,
-        objectStorageService,
-      );
+    await handleInvoiceCompleted(
+      fakeInvoiceCompletedSession,
+      usersService,
+      paymentService,
+      mockLogger(),
+      cacheService,
+      config,
+      objectStorageService,
+    );
 
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
-      expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
-      expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
-      expect(updateUserTier).toHaveBeenCalledTimes(1);
-      expect(usersRepository.updateUser).toHaveBeenCalledTimes(1);
-    });
-
-    it('When the user does not exist, then create a new one', async () => {
-      jest.spyOn(usersService, 'findUserByUuid').mockRejectedValue(new UserNotFoundError());
-
-      await handleInvoiceCompleted(
-        fakeInvoiceCompletedSession,
-        usersService,
-        paymentService,
-        mockLogger,
-        cacheService,
-        config,
-        objectStorageService,
-      );
-
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
-      expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
-      expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
-      expect(updateUserTier).toHaveBeenCalledTimes(1);
-      expect(usersRepository.updateUser).toHaveBeenCalledTimes(0);
-      expect(usersRepository.insertUser).toHaveBeenCalledTimes(1);
-    });
-
-    it('When creating the user fails, then throw an error', async () => {
-      jest.spyOn(usersService, 'findUserByUuid').mockRejectedValue(new UserNotFoundError());
-      jest.spyOn(usersRepository, 'insertUser').mockRejectedValue(new Error('Insert User Error'));
-
-      await expect(
-        handleInvoiceCompleted(
-          fakeInvoiceCompletedSession,
-          usersService,
-          paymentService,
-          mockLogger,
-          cacheService,
-          config,
-          objectStorageService,
-        ),
-      ).rejects.toThrow('Insert User Error');
-
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
-      expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
-      expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
-      expect(updateUserTier).toHaveBeenCalledTimes(1);
-      expect(usersRepository.insertUser).toHaveBeenCalledTimes(1);
-    });
-
-    it('When updating or creating the user fails, then log the error and throw an exception', async () => {
-      jest.spyOn(paymentService, 'getCustomer').mockResolvedValue({ deleted: false, customer: user.customerId } as any);
-      jest.spyOn(paymentService, 'getInvoiceLineItems').mockResolvedValue({
-        data: [
-          {
-            price: {
-              metadata: { maxSpaceBytes: 10 },
-              product: {},
-            },
-          },
-        ],
-      } as any);
-      jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([] as ExtendedSubscription[]);
-      (createOrUpdateUser as jest.Mock).mockResolvedValue(Promise.resolve({ data: { user } }));
-
-      await handleInvoiceCompleted(
-        fakeInvoiceCompletedSession,
-        usersService,
-        paymentService,
-        mockLogger,
-        cacheService,
-        config,
-        objectStorageService,
-      );
-
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
-      expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
-      expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
-    });
+    expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
+    expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
+    expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
+    expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
+    expect(updateUserTier).toHaveBeenCalledTimes(1);
+    expect(usersRepository.updateUser).toHaveBeenCalledTimes(1);
   });
 
-  describe('Invoice status', () => {
-    it('When the invoice is not paid, then log a message and take no action', async () => {
-      const fakeInvoiceCompletedSession = { status: 'open' } as unknown as Stripe.Invoice;
-      jest.spyOn(paymentService, 'getCustomer');
+  it('When the user does not exist, then create a new one', async () => {
+    jest.spyOn(usersService, 'findUserByUuid').mockRejectedValue(new UserNotFoundError());
 
-      await handleInvoiceCompleted(
-        fakeInvoiceCompletedSession,
-        usersService,
-        paymentService,
-        mockLogger,
-        cacheService,
-        config,
-        objectStorageService,
-      );
+    await handleInvoiceCompleted(
+      fakeInvoiceCompletedSession,
+      usersService,
+      paymentService,
+      mockLogger(),
+      cacheService,
+      config,
+      objectStorageService,
+    );
 
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(0);
-    });
+    expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
+    expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
+    expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
+    expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
+    expect(updateUserTier).toHaveBeenCalledTimes(1);
+    expect(usersRepository.updateUser).toHaveBeenCalledTimes(0);
+    expect(usersRepository.insertUser).toHaveBeenCalledTimes(1);
   });
 
-  describe('Customer cases', () => {
-    it('When the customer is marked as deleted, then log an error and stop processing', async () => {
-      const fakeInvoiceCompletedSession = { status: 'paid' } as unknown as Stripe.Invoice;
-      jest.spyOn(paymentService, 'getCustomer').mockResolvedValue({ deleted: true, customer: user.customerId } as any);
-      jest.spyOn(paymentService, 'getInvoiceLineItems');
+  it('When creating the user fails, then throw an error', async () => {
+    jest.spyOn(usersService, 'findUserByUuid').mockRejectedValue(new UserNotFoundError());
+    jest.spyOn(usersRepository, 'insertUser').mockRejectedValue(new Error('Insert User Error'));
 
-      await handleInvoiceCompleted(
+    await expect(
+      handleInvoiceCompleted(
         fakeInvoiceCompletedSession,
         usersService,
         paymentService,
-        mockLogger,
+        mockLogger(),
         cacheService,
         config,
         objectStorageService,
-      );
+      ),
+    ).rejects.toThrow('Insert User Error');
 
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('Invoice details', () => {
-    it('When the invoice lacks price or product details, then log an error and halt the process', async () => {
-      const fakeInvoiceCompletedSession = { status: 'paid' } as unknown as Stripe.Invoice;
-      jest.spyOn(paymentService, 'getCustomer').mockResolvedValue({ deleted: false, customer: user.customerId } as any);
-      jest.spyOn(paymentService, 'getInvoiceLineItems').mockResolvedValue([{}] as any);
-      jest.spyOn(paymentService, 'getActiveSubscriptions');
-
-      await handleInvoiceCompleted(
-        fakeInvoiceCompletedSession,
-        usersService,
-        paymentService,
-        mockLogger,
-        cacheService,
-        config,
-        objectStorageService,
-      );
-
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
-      expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('Plan level update', () => {
-    it("When updating the user's plan level fails, then log the error and throw an exception", async () => {
-      const fakeInvoiceCompletedSession = { status: 'paid' } as unknown as Stripe.Invoice;
-      jest.spyOn(paymentService, 'getCustomer').mockResolvedValue({ deleted: false, customer: user.customerId } as any);
-      jest.spyOn(paymentService, 'getInvoiceLineItems').mockResolvedValue({
-        data: [
-          {
-            price: {
-              metadata: { maxSpaceBytes: 10 },
-              product: {},
-            },
-          },
-        ],
-      } as any);
-      jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([] as ExtendedSubscription[]);
-      (createOrUpdateUser as jest.Mock).mockResolvedValue(Promise.resolve({ data: { user } }));
-      (updateUserTier as jest.Mock).mockResolvedValue(Promise.resolve());
-
-      await handleInvoiceCompleted(
-        fakeInvoiceCompletedSession,
-        usersService,
-        paymentService,
-        mockLogger,
-        cacheService,
-        config,
-        objectStorageService,
-      );
-
-      expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
-      expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
-      expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
-      expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
-      expect(updateUserTier).toHaveBeenCalledTimes(1);
-    });
+    expect(paymentService.getCustomer).toHaveBeenCalledTimes(1);
+    expect(paymentService.getInvoiceLineItems).toHaveBeenCalledTimes(1);
+    expect(paymentService.getActiveSubscriptions).toHaveBeenCalledTimes(1);
+    expect(createOrUpdateUser).toHaveBeenCalledTimes(1);
+    expect(updateUserTier).toHaveBeenCalledTimes(1);
+    expect(usersRepository.insertUser).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This PR refactors the way mocks are created and utilized in test cases. Previously, mocks were defined as constant variables, which limited flexibility and could lead to unintended state persistence across multiple tests.

With this update, mocks are now encapsulated within functions, ensuring that each test case receives a fresh and isolated mock instance when needed. This approach enhances test reliability, reduces potential side effects, and improves maintainability by providing greater control over mock initialization.

By implementing this change, we improve test consistency and make the mocking strategy more scalable for future test expansions.