### PR TITLE
[PB-3639]: fix/use-UUID-to-check-for-existing-users-before-creating-one

### DIFF
--- a/tests/src/payments.controller.test.ts
+++ b/tests/src/payments.controller.test.ts
@@ -201,7 +201,7 @@ describe('Payment controller e2e tests', () => {
       });
     });
 
-    it('When findUserByUuid throws a generic error, then an error indicating so is thrown', async () => {
+    it('When there is an unexpected error while fetching a customer by UUID, then an error indicating so is thrown', async () => {
       const unknownError = new Error('Unknown error');
       jest.spyOn(UsersService.prototype, 'findUserByUuid').mockRejectedValue(unknownError);
 


### PR DESCRIPTION
This PR updates the customer creation process by using the uuid to check if a user already exists in our database before creating a new customer in Stripe. Previously, this validation was based on the email address; however, since emails can change over time, they are not a reliable unique identifier. By switching to uuid, we ensure greater consistency and prevent duplicate customer records in Stripe.