### PR TITLE
[_]: tests/new-test-fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "test": "jest --detectOpenHandles",
     "test:cov": "jest --coverage",
+    "spec": "jest --testMatch='**/*.spec.ts'",
     "cli": "nodemon src/cli/load-license-codes.ts"
   },
   "engines": {

--- a/tests/src/fixtures.spec.ts
+++ b/tests/src/fixtures.spec.ts
@@ -12,7 +12,7 @@ import {
 import jwt from 'jsonwebtoken';
 
 describe('Test fixtures', () => {
-  describe('User fixture', () => {
+  describe("User's fixture", () => {
     describe('Generating a user', () => {
       it('When generating a user, then the UUID should be unique', () => {
         const user1 = getUser();
@@ -70,7 +70,7 @@ describe('Test fixtures', () => {
     });
   });
 
-  describe('getValidToken', () => {
+  describe("Token's fixtures", () => {
     it('When generating a token, then it should be a valid JWT', () => {
       const uuid = '223b88d7-f5a0-4592-a76c-22758c074757';
       const token = getValidToken(uuid);
@@ -83,13 +83,13 @@ describe('Test fixtures', () => {
     });
   });
 
-  describe('mockCustomerPayload', () => {
+  describe('Customers fixture', () => {
     it('When generating a customer payload, then it should have default values', () => {
       const customer = mockCustomerPayload();
 
-      expect(customer.id).toBe('cus_NffrFeUfNV2Hib');
-      expect(customer.email).toBe('example@inxt.com');
-      expect(customer.name).toBe('Jenny Rosen');
+      expect(customer.id).toMatch(/^cus_/);
+      expect(customer.email).toBe('example@internxt.com');
+      expect(customer.name).toBe('My internxt');
     });
 
     it('When passing custom parameters, then it should override the defaults', () => {
@@ -100,7 +100,7 @@ describe('Test fixtures', () => {
     });
   });
 
-  describe('mockPromotionCode', () => {
+  describe('Promotion code fixture', () => {
     it('When generating a promotion code, then it should have default values', () => {
       const promoCode = mockPromotionCode({});
 
@@ -115,7 +115,7 @@ describe('Test fixtures', () => {
     });
   });
 
-  describe('mockPrices', () => {
+  describe("Price's fixture", () => {
     it('When generating prices, then it should return predefined price IDs', () => {
       const prices = mockPrices();
 
@@ -124,43 +124,45 @@ describe('Test fixtures', () => {
     });
   });
 
-  describe('mockCreateSubscriptionResponse', () => {
-    it('When generating a subscription response, then it should have a default clientSecret', () => {
-      const response = mockCreateSubscriptionResponse();
+  describe("Subscription's fixture", () => {
+    describe('Created Subscription response', () => {
+      it('When generating a subscription response, then it should have a default clientSecret', () => {
+        const response = mockCreateSubscriptionResponse();
 
-      expect(response.type).toBe('payment');
-      expect(response.clientSecret).toBeDefined();
+        expect(response.type).toBe('payment');
+        expect(response.clientSecret).toBeDefined();
+      });
+
+      it('When passing custom parameters, then it should override the defaults', () => {
+        const response = mockCreateSubscriptionResponse({ clientSecret: 'custom_secret' });
+
+        expect(response.clientSecret).toBe('custom_secret');
+      });
     });
 
-    it('When passing custom parameters, then it should override the defaults', () => {
-      const response = mockCreateSubscriptionResponse({ clientSecret: 'custom_secret' });
+    describe('Created subscription object', () => {
+      it('When generating a subscription, then it should have default values', () => {
+        const subscription = createdSubscription();
 
-      expect(response.clientSecret).toBe('custom_secret');
+        expect(subscription.id).toMatch(/^sub_/);
+        expect(subscription.status).toBe('active');
+      });
+
+      it('When passing custom parameters, then it should override the defaults', () => {
+        const subscription = createdSubscription({ status: 'canceled' });
+
+        expect(subscription.status).toBe('canceled');
+      });
     });
-  });
 
-  describe('mockCreatedSubscriptionPayload', () => {
-    it('When generating a subscription, then it should have default values', () => {
-      const subscription = createdSubscription();
+    describe('Active subscriptions', () => {
+      it('When generating active subscriptions, then it should return the specified number of subscriptions', () => {
+        const subscriptions = mockActiveSubscriptions(2, [{ id: 'sub_123' }, { id: 'sub_456' }]);
 
-      expect(subscription.id).toBe('sub_1MowQVLkdIwHu7ixeRlqHVzs');
-      expect(subscription.status).toBe('active');
-    });
-
-    it('When passing custom parameters, then it should override the defaults', () => {
-      const subscription = createdSubscription({ status: 'canceled' });
-
-      expect(subscription.status).toBe('canceled');
-    });
-  });
-
-  describe('mockActiveSubscriptions', () => {
-    it('When generating active subscriptions, then it should return the specified number of subscriptions', () => {
-      const subscriptions = mockActiveSubscriptions(2, [{ id: 'sub_123' }, { id: 'sub_456' }]);
-
-      expect(subscriptions).toHaveLength(2);
-      expect(subscriptions[0].id).toBe('sub_123');
-      expect(subscriptions[1].id).toBe('sub_456');
+        expect(subscriptions).toHaveLength(2);
+        expect(subscriptions[0].id).toBe('sub_123');
+        expect(subscriptions[1].id).toBe('sub_456');
+      });
     });
   });
 });

--- a/tests/src/fixtures.spec.ts
+++ b/tests/src/fixtures.spec.ts
@@ -1,9 +1,9 @@
 import config from '../../src/config';
 import {
+  createdSubscription,
   getUser,
   getValidToken,
   mockActiveSubscriptions,
-  mockCreatedSubscriptionPayload,
   mockCreateSubscriptionResponse,
   mockCustomerPayload,
   mockPrices,
@@ -141,14 +141,14 @@ describe('Test fixtures', () => {
 
   describe('mockCreatedSubscriptionPayload', () => {
     it('When generating a subscription, then it should have default values', () => {
-      const subscription = mockCreatedSubscriptionPayload();
+      const subscription = createdSubscription();
 
       expect(subscription.id).toBe('sub_1MowQVLkdIwHu7ixeRlqHVzs');
       expect(subscription.status).toBe('active');
     });
 
     it('When passing custom parameters, then it should override the defaults', () => {
-      const subscription = mockCreatedSubscriptionPayload({ status: 'canceled' });
+      const subscription = createdSubscription({ status: 'canceled' });
 
       expect(subscription.status).toBe('canceled');
     });

--- a/tests/src/fixtures.spec.ts
+++ b/tests/src/fixtures.spec.ts
@@ -6,6 +6,7 @@ import {
   mockActiveSubscriptions,
   mockCreateSubscriptionResponse,
   mockCustomerPayload,
+  mockLogger,
   mockPrices,
   mockPromotionCode,
 } from './fixtures';
@@ -134,9 +135,9 @@ describe('Test fixtures', () => {
       });
 
       it('When passing custom parameters, then it should override the defaults', () => {
-        const response = mockCreateSubscriptionResponse({ clientSecret: 'custom_secret' });
+        const response = mockCreateSubscriptionResponse({ type: 'setup' });
 
-        expect(response.clientSecret).toBe('custom_secret');
+        expect(response.type).toBe('setup');
       });
     });
 
@@ -163,6 +164,33 @@ describe('Test fixtures', () => {
         expect(subscriptions[0].id).toBe('sub_123');
         expect(subscriptions[1].id).toBe('sub_456');
       });
+    });
+  });
+
+  describe('Logger fixture', () => {
+    it('When generating a logger, then all functions should be mocked', () => {
+      const logger = mockLogger();
+
+      expect(logger.info).toBeDefined();
+      expect(typeof logger.info).toBe('function');
+
+      expect(logger.error).toBeDefined();
+      expect(typeof logger.error).toBe('function');
+
+      expect(logger.warn).toBeDefined();
+      expect(typeof logger.warn).toBe('function');
+
+      expect(logger.debug).toBeDefined();
+      expect(typeof logger.debug).toBe('function');
+
+      expect(logger.fatal).toBeDefined();
+      expect(typeof logger.fatal).toBe('function');
+
+      expect(logger.trace).toBeDefined();
+      expect(typeof logger.trace).toBe('function');
+
+      expect(logger.silent).toBeDefined();
+      expect(typeof logger.silent).toBe('function');
     });
   });
 });

--- a/tests/src/fixtures.spec.ts
+++ b/tests/src/fixtures.spec.ts
@@ -1,0 +1,166 @@
+import config from '../../src/config';
+import {
+  getUser,
+  getValidToken,
+  mockActiveSubscriptions,
+  mockCreatedSubscriptionPayload,
+  mockCreateSubscriptionResponse,
+  mockCustomerPayload,
+  mockPrices,
+  mockPromotionCode,
+} from './fixtures';
+import jwt from 'jsonwebtoken';
+
+describe('Test fixtures', () => {
+  describe('User fixture', () => {
+    describe('Generating a user', () => {
+      it('When generating a user, then the UUID should be unique', () => {
+        const user1 = getUser();
+        const user2 = getUser();
+
+        expect(user1.uuid).toBeDefined();
+        expect(user1.uuid).not.toBe(user2.uuid);
+      });
+
+      it('When generating a user, then the customerId should be unique', () => {
+        const user1 = getUser();
+        const user2 = getUser();
+
+        expect(user1.customerId).toBeDefined();
+        expect(user1.customerId).not.toBe(user2.customerId);
+      });
+
+      it('When generating a user without specifying lifetime, then lifetime should be false', () => {
+        const user = getUser();
+        expect(user.lifetime).toBe(false);
+      });
+
+      it('When generating a user with lifetime set to true, then lifetime should be true', () => {
+        const user = getUser({ lifetime: true });
+        expect(user.lifetime).toBe(true);
+      });
+
+      it('When generating a user with custom parameters, then it should use the provided values', () => {
+        const customUser = {
+          id: 'customer-id',
+          uuid: 'customer-uuid',
+          customerId: 'cus_custom123',
+          lifetime: true,
+        };
+
+        const user = getUser(customUser);
+
+        expect(user.id).toBe(customUser.id);
+        expect(user.uuid).toBe(customUser.uuid);
+        expect(user.customerId).toBe(customUser.customerId);
+        expect(user.lifetime).toBe(customUser.lifetime);
+      });
+    });
+
+    describe('Ensuring uniqueness', () => {
+      it('When generating multiple users, then they should all have different UUIDs and customer IDs', () => {
+        const users = Array.from({ length: 5 }, () => getUser());
+
+        const uuids = users.map((user) => user.uuid);
+        const customerIds = users.map((user) => user.customerId);
+
+        expect(new Set(uuids).size).toBe(users.length);
+        expect(new Set(customerIds).size).toBe(users.length);
+      });
+    });
+  });
+
+  describe('getValidToken', () => {
+    it('When generating a token, then it should be a valid JWT', () => {
+      const uuid = '223b88d7-f5a0-4592-a76c-22758c074757';
+      const token = getValidToken(uuid);
+
+      expect(token).toBeDefined();
+      expect(typeof token).toBe('string');
+
+      const decoded = jwt.verify(token, config.JWT_SECRET) as any;
+      expect(decoded.payload.uuid).toBe(uuid);
+    });
+  });
+
+  describe('mockCustomerPayload', () => {
+    it('When generating a customer payload, then it should have default values', () => {
+      const customer = mockCustomerPayload();
+
+      expect(customer.id).toBe('cus_NffrFeUfNV2Hib');
+      expect(customer.email).toBe('example@inxt.com');
+      expect(customer.name).toBe('Jenny Rosen');
+    });
+
+    it('When passing custom parameters, then it should override the defaults', () => {
+      const customer = mockCustomerPayload({ email: 'custom@example.com', name: 'Custom Name' });
+
+      expect(customer.email).toBe('custom@example.com');
+      expect(customer.name).toBe('Custom Name');
+    });
+  });
+
+  describe('mockPromotionCode', () => {
+    it('When generating a promotion code, then it should have default values', () => {
+      const promoCode = mockPromotionCode({});
+
+      expect(promoCode.codeId).toBe('promo_id');
+      expect(promoCode.percentOff).toBe(75);
+    });
+
+    it('When passing custom parameters, then it should override the defaults', () => {
+      const promoCode = mockPromotionCode({ percentOff: 50 });
+
+      expect(promoCode.percentOff).toBe(50);
+    });
+  });
+
+  describe('mockPrices', () => {
+    it('When generating prices, then it should return predefined price IDs', () => {
+      const prices = mockPrices();
+
+      expect(prices.subscription.exists).toBe('price_1PLMh8FAOdcgaBMQlZcGAPY4');
+      expect(prices.lifetime.doesNotExist).toBe('price_1PLMVCFAOdcgaBMQxIQgdXsds');
+    });
+  });
+
+  describe('mockCreateSubscriptionResponse', () => {
+    it('When generating a subscription response, then it should have a default clientSecret', () => {
+      const response = mockCreateSubscriptionResponse();
+
+      expect(response.type).toBe('payment');
+      expect(response.clientSecret).toBeDefined();
+    });
+
+    it('When passing custom parameters, then it should override the defaults', () => {
+      const response = mockCreateSubscriptionResponse({ clientSecret: 'custom_secret' });
+
+      expect(response.clientSecret).toBe('custom_secret');
+    });
+  });
+
+  describe('mockCreatedSubscriptionPayload', () => {
+    it('When generating a subscription, then it should have default values', () => {
+      const subscription = mockCreatedSubscriptionPayload();
+
+      expect(subscription.id).toBe('sub_1MowQVLkdIwHu7ixeRlqHVzs');
+      expect(subscription.status).toBe('active');
+    });
+
+    it('When passing custom parameters, then it should override the defaults', () => {
+      const subscription = mockCreatedSubscriptionPayload({ status: 'canceled' });
+
+      expect(subscription.status).toBe('canceled');
+    });
+  });
+
+  describe('mockActiveSubscriptions', () => {
+    it('When generating active subscriptions, then it should return the specified number of subscriptions', () => {
+      const subscriptions = mockActiveSubscriptions(2, [{ id: 'sub_123' }, { id: 'sub_456' }]);
+
+      expect(subscriptions).toHaveLength(2);
+      expect(subscriptions[0].id).toBe('sub_123');
+      expect(subscriptions[1].id).toBe('sub_456');
+    });
+  });
+});

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -25,7 +25,7 @@ export const getValidToken = (userUuid: string): string => {
 
 export const mockCustomerPayload = (params?: Partial<Stripe.Customer>): Stripe.Customer => {
   return {
-    id: 'cus_NffrFeUfNV2Hib',
+    id: `cus_${randomDataGenerator.string({ length: 12 })}`,
     object: 'customer',
     address: null,
     balance: 0,
@@ -35,7 +35,7 @@ export const mockCustomerPayload = (params?: Partial<Stripe.Customer>): Stripe.C
     delinquent: false,
     description: null,
     discount: null,
-    email: 'example@inxt.com',
+    email: 'example@internxt.com',
     invoice_prefix: '0759376C',
     invoice_settings: {
       custom_fields: null,
@@ -45,7 +45,7 @@ export const mockCustomerPayload = (params?: Partial<Stripe.Customer>): Stripe.C
     },
     livemode: false,
     metadata: {},
-    name: 'Jenny Rosen',
+    name: 'My internxt',
     next_invoice_sequence: 1,
     phone: null,
     preferred_locales: [],
@@ -87,9 +87,9 @@ export const mockCreateSubscriptionResponse = (params?: Partial<SubscriptionCrea
   };
 };
 
-export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscription>): Stripe.Subscription => {
+export const createdSubscription = (params?: Partial<Stripe.Subscription>): Stripe.Subscription => {
   return {
-    id: 'sub_1MowQVLkdIwHu7ixeRlqHVzs',
+    id: `sub_${randomDataGenerator.string({ length: 14 })}`,
     object: 'subscription',
     billing_cycle_anchor_config: {
       day_of_month: 1,
@@ -108,7 +108,7 @@ export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscript
       enabled: false,
       liability: null,
     },
-    billing_cycle_anchor: 1679609767,
+    billing_cycle_anchor: randomDataGenerator.natural({ length: 10 }),
     billing_thresholds: null,
     cancel_at: null,
     cancel_at_period_end: false,
@@ -119,11 +119,11 @@ export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscript
       reason: null,
     },
     collection_method: 'charge_automatically',
-    created: 1679609767,
+    created: randomDataGenerator.natural({ length: 10 }),
     currency: 'usd',
-    current_period_end: 1682288167,
-    current_period_start: 1679609767,
-    customer: 'cus_Na6dX7aXxi11N4',
+    current_period_end: randomDataGenerator.natural({ length: 10 }),
+    current_period_start: randomDataGenerator.natural({ length: 10 }),
+    customer: `cus_${randomDataGenerator.string({ length: 12 })}`,
     days_until_due: null,
     default_payment_method: null,
     default_source: null,
@@ -136,46 +136,46 @@ export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscript
       object: 'list',
       data: [
         {
-          id: 'si_Na6dzxczY5fwHx',
+          id: `si_${randomDataGenerator.string({ length: 12 })}`,
           object: 'subscription_item',
           billing_thresholds: null,
-          created: 1679609768,
+          created: randomDataGenerator.natural({ length: 10 }),
           metadata: {},
           discounts: null as any,
           plan: {
-            id: 'price_1MowQULkdIwHu7ixraBm864M',
+            id: `price_${randomDataGenerator.string({ length: 20 })}`,
             object: 'plan',
             active: true,
             aggregate_usage: null,
             amount: 1000,
             amount_decimal: '1000',
             billing_scheme: 'per_unit',
-            created: 1679609766,
+            created: randomDataGenerator.natural({ length: 10 }),
             currency: 'usd',
             interval: 'month',
             interval_count: 1,
             livemode: false,
             metadata: {},
             nickname: null,
-            product: 'prod_Na6dGcTsmU0I4R',
+            product: `prod_${randomDataGenerator.string({ length: 15 })}`,
             tiers_mode: null,
             transform_usage: null,
             trial_period_days: null,
             usage_type: 'licensed',
           },
           price: {
-            id: 'price_1MowQULkdIwHu7ixraBm864M',
+            id: `price_${randomDataGenerator.string({ length: 12 })}`,
             object: 'price',
             active: true,
             billing_scheme: 'per_unit',
-            created: 1679609766,
+            created: randomDataGenerator.natural({ length: 10 }),
             currency: 'usd',
             custom_unit_amount: null,
             livemode: false,
             lookup_key: null,
             metadata: {},
             nickname: null,
-            product: 'prod_Na6dGcTsmU0I4R',
+            product: `prod_${randomDataGenerator.string({ length: 12 })}`,
             recurring: {
               aggregate_usage: null,
               interval: 'month',
@@ -191,14 +191,14 @@ export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscript
             unit_amount_decimal: '1000',
           },
           quantity: 1,
-          subscription: 'sub_1MowQVLkdIwHu7ixeRlqHVzs',
+          subscription: `sub_${randomDataGenerator.string({ length: 12 })}`,
           tax_rates: [],
         },
       ],
       has_more: false,
       url: '/v1/subscription_items?subscription=sub_1MowQVLkdIwHu7ixeRlqHVzs',
     },
-    latest_invoice: 'in_1MowQWLkdIwHu7ixuzkSPfKd',
+    latest_invoice: `in_${randomDataGenerator.string({ length: 14 })}`,
     livemode: false,
     metadata: {},
     next_pending_invoice_item_invoice: null,
@@ -213,7 +213,7 @@ export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscript
     pending_setup_intent: null,
     pending_update: null,
     schedule: null,
-    start_date: 1679609767,
+    start_date: randomDataGenerator.natural({ length: 10 }),
     status: 'active',
     test_clock: null,
     transfer_data: null,
@@ -233,7 +233,7 @@ export const mockActiveSubscriptions = (
   paramsArray: Partial<Stripe.Subscription>[] = [],
 ): Stripe.Subscription[] => {
   return Array.from({ length: count }, (_, index) => ({
-    ...mockCreatedSubscriptionPayload(),
+    ...createdSubscription(),
     ...paramsArray[index],
   }));
 };

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -1,0 +1,295 @@
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+import { FastifyBaseLogger } from 'fastify';
+import { Chance } from 'chance';
+import config from '../../src/config';
+import { User } from '../../src/core/users/User';
+import { Tier } from '../../src/core/users/MongoDBTiersRepository';
+import Stripe from 'stripe';
+import { PaymentIntent, PromotionCode, SubscriptionCreated } from '../../src/services/payment.service';
+import { Coupon } from '../../src/core/coupons/Coupon';
+
+const randomDataGenerator = new Chance();
+
+export const getUser = (params?: Partial<User>): User => ({
+  id: randomDataGenerator.string({ length: 12 }),
+  uuid: randomUUID(),
+  customerId: `cus_${randomDataGenerator.string({ length: 10 })}`,
+  lifetime: false,
+  ...params,
+});
+
+export const getValidToken = (userUuid: string): string => {
+  return jwt.sign({ payload: { uuid: userUuid } }, config.JWT_SECRET);
+};
+
+export const mockCustomerPayload = (params?: Partial<Stripe.Customer>): Stripe.Customer => {
+  return {
+    id: 'cus_NffrFeUfNV2Hib',
+    object: 'customer',
+    address: null,
+    balance: 0,
+    created: 1680893993,
+    currency: null,
+    default_source: null,
+    delinquent: false,
+    description: null,
+    discount: null,
+    email: 'example@inxt.com',
+    invoice_prefix: '0759376C',
+    invoice_settings: {
+      custom_fields: null,
+      default_payment_method: null,
+      footer: null,
+      rendering_options: null,
+    },
+    livemode: false,
+    metadata: {},
+    name: 'Jenny Rosen',
+    next_invoice_sequence: 1,
+    phone: null,
+    preferred_locales: [],
+    shipping: null,
+    tax_exempt: 'none',
+    test_clock: null,
+    ...params,
+  };
+};
+
+export const mockPromotionCode = (params: Partial<PromotionCode>): PromotionCode => {
+  return {
+    codeId: 'promo_id',
+    promoCodeName: 'PROMO_NAME',
+    amountOff: null,
+    percentOff: 75,
+    ...params,
+  };
+};
+
+export const mockPrices = () => {
+  return {
+    subscription: {
+      exists: 'price_1PLMh8FAOdcgaBMQlZcGAPY4',
+      doesNotExist: 'price_1PLMerFAOdcgaBMQ17q27Cas',
+    },
+    lifetime: {
+      exists: 'price_1PLMTpFAOdcgaBMQ0Jag685H',
+      doesNotExist: 'price_1PLMVCFAOdcgaBMQxIQgdXsds',
+    },
+  };
+};
+
+export const mockCreateSubscriptionResponse = (params?: Partial<SubscriptionCreated>): SubscriptionCreated => {
+  return {
+    type: 'payment',
+    clientSecret: `ci_${randomDataGenerator.string({ length: 8 })}`,
+    ...params,
+  };
+};
+
+export const mockCreatedSubscriptionPayload = (params?: Partial<Stripe.Subscription>): Stripe.Subscription => {
+  return {
+    id: 'sub_1MowQVLkdIwHu7ixeRlqHVzs',
+    object: 'subscription',
+    billing_cycle_anchor_config: {
+      day_of_month: 1,
+      hour: 0,
+      minute: 0,
+      month: 1,
+      second: 0,
+    },
+    invoice_settings: {
+      account_tax_ids: null,
+      issuer: 'Stripe' as any,
+    },
+    application: null,
+    application_fee_percent: null,
+    automatic_tax: {
+      enabled: false,
+      liability: null,
+    },
+    billing_cycle_anchor: 1679609767,
+    billing_thresholds: null,
+    cancel_at: null,
+    cancel_at_period_end: false,
+    canceled_at: null,
+    cancellation_details: {
+      comment: null,
+      feedback: null,
+      reason: null,
+    },
+    collection_method: 'charge_automatically',
+    created: 1679609767,
+    currency: 'usd',
+    current_period_end: 1682288167,
+    current_period_start: 1679609767,
+    customer: 'cus_Na6dX7aXxi11N4',
+    days_until_due: null,
+    default_payment_method: null,
+    default_source: null,
+    default_tax_rates: [],
+    description: null,
+    discount: null,
+    discounts: null as any,
+    ended_at: null,
+    items: {
+      object: 'list',
+      data: [
+        {
+          id: 'si_Na6dzxczY5fwHx',
+          object: 'subscription_item',
+          billing_thresholds: null,
+          created: 1679609768,
+          metadata: {},
+          discounts: null as any,
+          plan: {
+            id: 'price_1MowQULkdIwHu7ixraBm864M',
+            object: 'plan',
+            active: true,
+            aggregate_usage: null,
+            amount: 1000,
+            amount_decimal: '1000',
+            billing_scheme: 'per_unit',
+            created: 1679609766,
+            currency: 'usd',
+            interval: 'month',
+            interval_count: 1,
+            livemode: false,
+            metadata: {},
+            nickname: null,
+            product: 'prod_Na6dGcTsmU0I4R',
+            tiers_mode: null,
+            transform_usage: null,
+            trial_period_days: null,
+            usage_type: 'licensed',
+          },
+          price: {
+            id: 'price_1MowQULkdIwHu7ixraBm864M',
+            object: 'price',
+            active: true,
+            billing_scheme: 'per_unit',
+            created: 1679609766,
+            currency: 'usd',
+            custom_unit_amount: null,
+            livemode: false,
+            lookup_key: null,
+            metadata: {},
+            nickname: null,
+            product: 'prod_Na6dGcTsmU0I4R',
+            recurring: {
+              aggregate_usage: null,
+              interval: 'month',
+              interval_count: 1,
+              trial_period_days: null,
+              usage_type: 'licensed',
+            },
+            tax_behavior: 'unspecified',
+            tiers_mode: null,
+            transform_quantity: null,
+            type: 'recurring',
+            unit_amount: 1000,
+            unit_amount_decimal: '1000',
+          },
+          quantity: 1,
+          subscription: 'sub_1MowQVLkdIwHu7ixeRlqHVzs',
+          tax_rates: [],
+        },
+      ],
+      has_more: false,
+      url: '/v1/subscription_items?subscription=sub_1MowQVLkdIwHu7ixeRlqHVzs',
+    },
+    latest_invoice: 'in_1MowQWLkdIwHu7ixuzkSPfKd',
+    livemode: false,
+    metadata: {},
+    next_pending_invoice_item_invoice: null,
+    on_behalf_of: null,
+    pause_collection: null,
+    payment_settings: {
+      payment_method_options: null,
+      payment_method_types: null,
+      save_default_payment_method: 'off',
+    },
+    pending_invoice_item_interval: null,
+    pending_setup_intent: null,
+    pending_update: null,
+    schedule: null,
+    start_date: 1679609767,
+    status: 'active',
+    test_clock: null,
+    transfer_data: null,
+    trial_end: null,
+    trial_settings: {
+      end_behavior: {
+        missing_payment_method: 'create_invoice',
+      },
+    },
+    trial_start: null,
+    ...params,
+  };
+};
+
+export const mockActiveSubscriptions = (
+  count: number = 1,
+  paramsArray: Partial<Stripe.Subscription>[] = [],
+): Stripe.Subscription[] => {
+  return Array.from({ length: count }, (_, index) => ({
+    ...mockCreatedSubscriptionPayload(),
+    ...paramsArray[index],
+  }));
+};
+
+export const mockPaymentIntentResponse = (params?: Partial<PaymentIntent>): PaymentIntent => {
+  return {
+    id: `pi_${randomDataGenerator.string({ length: 10 })}`,
+    clientSecret: 'client_secret',
+    invoiceStatus: 'open',
+    ...params,
+  };
+};
+
+export const mockCoupon = (params?: Partial<Coupon>): Coupon => ({
+  id: randomUUID(),
+  provider: 'stripe',
+  code: 'c0UP0n',
+  ...params,
+});
+
+export const newTier = (params?: Partial<Tier>): Tier => {
+  return {
+    billingType: 'subscription',
+    label: 'test-label',
+    productId: randomDataGenerator.string({ length: 15 }),
+    featuresPerService: {
+      mail: { enabled: false, addressesPerUser: randomDataGenerator.integer({ min: 0, max: 5 }) },
+      meet: { enabled: false, paxPerCall: randomDataGenerator.integer({ min: 0, max: 5 }) },
+      vpn: { enabled: false, locationsAvailable: randomDataGenerator.integer({ min: 0, max: 5 }) },
+      antivirus: { enabled: false },
+      backups: { enabled: false },
+      drive: {
+        enabled: false,
+        maxSpaceBytes: randomDataGenerator.integer({ min: 1024 * 1024 * 1024, max: 5 * 1024 * 1024 * 1024 }),
+        workspaces: {
+          enabled: false,
+          maximumSeats: randomDataGenerator.integer({ min: 10, max: 100 }),
+          minimumSeats: 3,
+          maxSpaceBytesPerSeat: randomDataGenerator.integer({ min: 1024 * 1024 * 1024, max: 5 * 1024 * 1024 * 1024 }),
+        },
+      },
+    },
+    ...params,
+  };
+};
+
+export const mockLogger = (): jest.Mocked<FastifyBaseLogger> => {
+  return {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+    level: 'info',
+    silent: jest.fn(),
+    child: jest.fn(),
+  };
+};


### PR DESCRIPTION
This PR refactors the way mocks are created and utilized in test cases. Previously, mocks were defined as constant variables, which limited flexibility and could lead to unintended state persistence across multiple tests.

With this update, mocks are now encapsulated within functions, ensuring that each test case receives a fresh and isolated mock instance when needed. This approach enhances test reliability, reduces potential side effects, and improves maintainability by providing greater control over mock initialization.

By implementing this change, we improve test consistency and make the mocking strategy more scalable for future test expansions.