### PR TITLE
[PB-3884]: feat/store-users-tiers-relationship

### DIFF
--- a/src/core/users/MongoDBUsersTiersRepository.ts
+++ b/src/core/users/MongoDBUsersTiersRepository.ts
@@ -1,0 +1,58 @@
+import { Collection, MongoClient, WithId } from 'mongodb';
+import { Tier } from './Tier';
+import { User } from './User';
+
+interface UserTier {
+  id: string;
+  userId: User['id'];
+  tierId: Tier['id'];
+}
+
+export interface UsersTiersRepository {
+  insertTierToUser(userId: User['id'], tierId: Tier['id']): Promise<void>;
+  updateUserTier(userId: User['id'], oldTierId: Tier['id'], newTierId: Tier['id']): Promise<boolean>;
+  deleteTierFromUser(userId: User['id'], tierId: Tier['id']): Promise<boolean>;
+  deleteAllUserTiers(userId: User['id']): Promise<void>;
+  findTierIdByUserId(userId: User['id']): Promise<UserTier[]>;
+}
+
+function toDomain(userTier: WithId<Omit<UserTier, 'id'>>): UserTier {
+  return {
+    ...userTier,
+    id: userTier._id.toString(),
+  };
+}
+
+export class MongoDBUsersTiersRepository implements UsersTiersRepository {
+  private readonly collection: Collection<Omit<UserTier, 'id'>>;
+
+  constructor(mongo: MongoClient) {
+    this.collection = mongo.db('payments').collection<Omit<UserTier, 'id'>>('users_tiers');
+  }
+
+  async insertTierToUser(userId: User['id'], tierId: Tier['id']): Promise<void> {
+    await this.collection.insertOne({
+      userId,
+      tierId,
+    });
+  }
+
+  async findTierIdByUserId(userId: User['id']): Promise<UserTier[]> {
+    const userTiers = await this.collection.find({ userId }).toArray();
+    return userTiers.map(toDomain);
+  }
+
+  async updateUserTier(userId: User['id'], oldTierId: Tier['id'], newTierId: Tier['id']): Promise<boolean> {
+    const result = await this.collection.updateOne({ userId, tierId: oldTierId }, { $set: { tierId: newTierId } });
+    return result.modifiedCount > 0;
+  }
+
+  async deleteTierFromUser(userId: User['id'], tierId: Tier['id']): Promise<boolean> {
+    const result = await this.collection.deleteOne({ userId, tierId });
+    return result.deletedCount > 0;
+  }
+
+  async deleteAllUserTiers(userId: User['id']): Promise<void> {
+    await this.collection.deleteMany({ userId });
+  }
+}

--- a/src/core/users/Tier.ts
+++ b/src/core/users/Tier.ts
@@ -1,0 +1,57 @@
+interface AntivirusFeatures {
+  enabled: boolean;
+}
+
+interface BackupsFeatures {
+  enabled: boolean;
+}
+
+export interface DriveFeatures {
+  enabled: boolean;
+  maxSpaceBytes: number;
+  workspaces: {
+    enabled: boolean;
+    minimumSeats: number;
+    maximumSeats: number;
+    maxSpaceBytesPerSeat: number;
+  };
+}
+
+interface MeetFeatures {
+  enabled: boolean;
+  paxPerCall: number;
+}
+
+interface MailFeatures {
+  enabled: boolean;
+  addressesPerUser: number;
+}
+
+export interface VpnFeatures {
+  enabled: boolean;
+  featureId: string;
+}
+
+export enum Service {
+  Drive = 'drive',
+  Backups = 'backups',
+  Antivirus = 'antivirus',
+  Meet = 'meet',
+  Mail = 'mail',
+  Vpn = 'vpn',
+}
+
+export interface Tier {
+  id: string;
+  label: string;
+  productId: string;
+  billingType: 'subscription' | 'lifetime';
+  featuresPerService: {
+    [Service.Drive]: DriveFeatures;
+    [Service.Backups]: BackupsFeatures;
+    [Service.Antivirus]: AntivirusFeatures;
+    [Service.Meet]: MeetFeatures;
+    [Service.Mail]: MailFeatures;
+    [Service.Vpn]: VpnFeatures;
+  };
+}

--- a/src/services/tiers.service.ts
+++ b/src/services/tiers.service.ts
@@ -1,9 +1,10 @@
-import { Service, Tier, TiersRepository } from '../core/users/MongoDBTiersRepository';
+import { TiersRepository } from '../core/users/MongoDBTiersRepository';
 import { User } from '../core/users/User';
 import { UsersService } from './users.service';
 import { createOrUpdateUser, updateUserTier } from './storage.service';
 import { AppConfig } from '../config';
 import { CustomerId, NotFoundSubscriptionError, PaymentService } from './payment.service';
+import { Service, Tier } from '../core/users/Tier';
 
 export class TierNotFoundError extends Error {
   constructor(productId: Tier['productId']) {

--- a/tests/src/core/users/MongoDBTiersRepository.test.ts
+++ b/tests/src/core/users/MongoDBTiersRepository.test.ts
@@ -1,0 +1,70 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient } from 'mongodb';
+import { MongoDBTiersRepository } from '../../../../src/core/users/MongoDBTiersRepository';
+import { Tier } from '../../../../src/core/users/Tier';
+import { newTier } from '../../fixtures';
+
+describe('Testing the tier collection', () => {
+  let mongoServer: MongoMemoryServer;
+  let client: MongoClient;
+  let repository: MongoDBTiersRepository;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+
+    client = new MongoClient(uri);
+    await client.connect();
+
+    repository = new MongoDBTiersRepository(client);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    const collection = (repository as any).collection;
+    await collection.deleteMany({});
+  });
+
+  it('when a tier is searched by a non-existing productId, then it should return null', async () => {
+    const result = await repository.findByProductId('non-existent');
+    expect(result).toBeNull();
+  });
+
+  it('when a tier is searched by the product Id, then it should be found and match the inserted data', async () => {
+    const collection = (repository as any).collection;
+    const mockTier: Omit<Tier, 'id'> = newTier();
+    const insertResult = await collection.insertOne(mockTier);
+
+    const foundTier = await repository.findByProductId(mockTier.productId);
+
+    expect(foundTier).not.toBeNull();
+    expect(foundTier?.id).toBe(insertResult.insertedId.toString());
+    expect(foundTier?.productId).toBe(mockTier.productId);
+    expect(foundTier?.label).toBe(mockTier.label);
+    expect(foundTier?.featuresPerService).toStrictEqual(mockTier.featuresPerService);
+  });
+
+  it('when a tier is searched by a non-existing id, then it should return null', async () => {
+    const result = await repository.findById('64b5b7fb69f1a8eb2ab4bad6');
+    expect(result).toBeNull();
+  });
+
+  it('when a tier is searched by id, then it should be found and match the inserted data', async () => {
+    const collection = (repository as any).collection;
+    const mockTier: Omit<Tier, 'id'> = newTier();
+    const insertResult = await collection.insertOne(mockTier);
+    const insertedId = insertResult.insertedId.toString();
+
+    const foundTier = await repository.findById(insertedId);
+
+    expect(foundTier).not.toBeNull();
+    expect(foundTier?.id).toBe(insertedId);
+    expect(foundTier?.productId).toBe(mockTier.productId);
+    expect(foundTier?.label).toBe(mockTier.label);
+    expect(foundTier?.featuresPerService).toStrictEqual(mockTier.featuresPerService);
+  });
+});

--- a/tests/src/core/users/MongoDBUsersTiersRepository.test.ts
+++ b/tests/src/core/users/MongoDBUsersTiersRepository.test.ts
@@ -1,0 +1,113 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient } from 'mongodb';
+import { MongoDBUsersTiersRepository } from '../../../../src/core/users/MongoDBUsersTiersRepository';
+import { getUser, newTier } from '../../fixtures';
+
+describe('Testing the users and tiers collection', () => {
+  let mongoServer: MongoMemoryServer;
+  let client: MongoClient;
+  let repository: MongoDBUsersTiersRepository;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    client = new MongoClient(uri);
+    await client.connect();
+    repository = new MongoDBUsersTiersRepository(client);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    const collection = (repository as any).collection;
+    await collection.deleteMany({});
+  });
+
+  it('when inserting a tier for a user, then it should be stored correctly', async () => {
+    const { id: userId } = getUser();
+    const { id: tierId } = newTier();
+
+    await repository.insertTierToUser(userId, tierId);
+
+    const userTiers = await repository.findTierIdByUserId(userId);
+    expect(userTiers).toHaveLength(1);
+    expect(userTiers[0].userId).toBe(userId);
+    expect(userTiers[0].tierId).toBe(tierId);
+    expect(userTiers[0].id).toBeDefined();
+  });
+
+  it('when finding multiple tiers for the same user, then it should return all assigned tiers', async () => {
+    const { id: userId } = getUser();
+    const { id: tierId1 } = newTier();
+    const { id: tierId2 } = newTier();
+
+    await repository.insertTierToUser(userId, tierId1);
+    await repository.insertTierToUser(userId, tierId2);
+
+    const userTiers = await repository.findTierIdByUserId(userId);
+    expect(userTiers).toHaveLength(2);
+    const tierIds = userTiers.map((ut) => ut.tierId);
+    expect(tierIds).toContain(tierId1);
+    expect(tierIds).toContain(tierId2);
+  });
+
+  it('when updating a user’s tier, then the tier should be updated successfully', async () => {
+    const { id: userId } = getUser();
+    const { id: oldTierId } = newTier();
+    const { id: newTierId } = newTier();
+
+    await repository.insertTierToUser(userId, oldTierId);
+    const updated = await repository.updateUserTier(userId, oldTierId, newTierId);
+
+    expect(updated).toBe(true);
+    const userTiers = await repository.findTierIdByUserId(userId);
+    expect(userTiers).toHaveLength(1);
+    expect(userTiers[0].tierId).toBe(newTierId);
+  });
+
+  it('when trying to update a non-existing tier, then it should return false', async () => {
+    const { id: userId } = getUser();
+    const { id: oldTierId } = newTier();
+    const { id: newTierId } = newTier();
+
+    const updated = await repository.updateUserTier(userId, oldTierId, newTierId);
+    expect(updated).toBe(false);
+  });
+
+  it('when deleting a tier from a user, then the tier should be removed successfully', async () => {
+    const { id: userId } = getUser();
+    const { id: tierId } = newTier();
+
+    await repository.insertTierToUser(userId, tierId);
+    const deleted = await repository.deleteTierFromUser(userId, tierId);
+
+    expect(deleted).toBe(true);
+    const userTiers = await repository.findTierIdByUserId(userId);
+    expect(userTiers).toHaveLength(0);
+  });
+
+  it('when trying to delete a non-existing tier, then it should return false', async () => {
+    const { id: userId } = getUser();
+    const { id: tierId } = newTier();
+
+    const deleted = await repository.deleteTierFromUser(userId, tierId);
+    expect(deleted).toBe(false);
+  });
+
+  it('when deleting all tiers from a user, then all tiers should be removed', async () => {
+    const { id: userId } = getUser();
+
+    await repository.insertTierToUser(userId, 'tier1');
+    await repository.insertTierToUser(userId, 'tier2');
+
+    let userTiers = await repository.findTierIdByUserId(userId);
+    expect(userTiers).toHaveLength(2);
+
+    await repository.deleteAllUserTiers(userId);
+    userTiers = await repository.findTierIdByUserId(userId);
+    expect(userTiers).toHaveLength(0);
+  });
+});

--- a/tests/src/fixtures.spec.ts
+++ b/tests/src/fixtures.spec.ts
@@ -128,7 +128,7 @@ describe('Test fixtures', () => {
     it('When generating prices, then it should return predefined price IDs', () => {
       const prices = getPrices();
 
-      expect(prices.subscription.exists).toBe('price_1PLMh8FAOdcgaBMQlZcGAPY4');
+      expect(prices.subscription.exists).toBe('price_1Qtm4MFAOdcgaBMQ0cUPiqRA');
       expect(prices.lifetime.doesNotExist).toBe('price_1PLMVCFAOdcgaBMQxIQgdXsds');
     });
   });

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -4,11 +4,11 @@ import { FastifyBaseLogger } from 'fastify';
 import { Chance } from 'chance';
 import config from '../../src/config';
 import { User, UserType } from '../../src/core/users/User';
-import { Tier } from '../../src/core/users/MongoDBTiersRepository';
 import Stripe from 'stripe';
 import { PaymentIntent, PromotionCode, SubscriptionCreated } from '../../src/services/payment.service';
 import { Coupon } from '../../src/core/coupons/Coupon';
 import { Currency } from '../../src/services/bit2me.service';
+import { Tier } from '../../src/core/users/Tier';
 
 const randomDataGenerator = new Chance();
 
@@ -70,11 +70,11 @@ export const getPromotionCode = (params?: Partial<PromotionCode>): PromotionCode
 export const getPrices = () => {
   return {
     subscription: {
-      exists: 'price_1PLMh8FAOdcgaBMQlZcGAPY4',
+      exists: 'price_1Qtm4MFAOdcgaBMQ0cUPiqRA',
       doesNotExist: 'price_1PLMerFAOdcgaBMQ17q27Cas',
     },
     lifetime: {
-      exists: 'price_1PLMTpFAOdcgaBMQ0Jag685H',
+      exists: 'price_1Qtm4MFAOdcgaBMQimNiZsnl',
       doesNotExist: 'price_1PLMVCFAOdcgaBMQxIQgdXsds',
     },
   };
@@ -387,13 +387,14 @@ export const getCoupon = (params?: Partial<Coupon>): Coupon => ({
 
 export const newTier = (params?: Partial<Tier>): Tier => {
   return {
+    id: randomDataGenerator.string({ length: 10 }),
     billingType: 'subscription',
     label: 'test-label',
     productId: randomDataGenerator.string({ length: 15 }),
     featuresPerService: {
       mail: { enabled: false, addressesPerUser: randomDataGenerator.integer({ min: 0, max: 5 }) },
       meet: { enabled: false, paxPerCall: randomDataGenerator.integer({ min: 0, max: 5 }) },
-      vpn: { enabled: false, locationsAvailable: randomDataGenerator.integer({ min: 0, max: 5 }) },
+      vpn: { enabled: false, featureId: randomDataGenerator.string({ length: 10 }) },
       antivirus: { enabled: false },
       backups: { enabled: false },
       drive: {

--- a/tests/src/payments.controller.test.ts
+++ b/tests/src/payments.controller.test.ts
@@ -87,14 +87,6 @@ describe('Payment controller e2e tests', () => {
             interval: expect.anything(),
             decimalAmount: expect.anything(),
           },
-          upsellPlan: {
-            id: expect.anything(),
-            currency: expect.anything(),
-            amount: expect.anything(),
-            bytes: expect.anything(),
-            interval: expect.anything(),
-            decimalAmount: expect.anything(),
-          },
         };
 
         const response = await app.inject({

--- a/tests/src/services/tiers.service.test.ts
+++ b/tests/src/services/tiers.service.test.ts
@@ -9,7 +9,7 @@ import {
   TiersService,
 } from '../../../src/services/tiers.service';
 import { UsersService } from '../../../src/services/users.service';
-import { Service, TiersRepository } from '../../../src/core/users/MongoDBTiersRepository';
+import { TiersRepository } from '../../../src/core/users/MongoDBTiersRepository';
 import { UsersRepository } from '../../../src/core/users/UsersRepository';
 import {
   CustomerId,
@@ -24,6 +24,7 @@ import { UsersCouponsRepository } from '../../../src/core/coupons/UsersCouponsRe
 import { ProductsRepository } from '../../../src/core/users/ProductsRepository';
 import { Bit2MeService } from '../../../src/services/bit2me.service';
 import { getUser, newTier } from '../fixtures';
+import { Service } from '../../../src/core/users/Tier';
 
 let tiersService: TiersService;
 let paymentsService: PaymentService;


### PR DESCRIPTION
This PR introduces the implementation of the user-tier relationship in MongoDB. The feature allows users to be linked to different tiers, ensuring that the assigned subscription or lifetime plan is correctly stored and retrieved.

### **Changes Implemented:**
- Created MongoDBUsersTiersRepository to handle user-tier assignments.
- Implemented methods to:
  - Insert a tier for a user.
  - Retrieve all assigned tiers for a user.
  - Update a user's assigned tier.
  - Remove a specific tier from a user.
  - Delete all tiers assigned to a user.
- Added unit tests to verify that the repository correctly manages the user-tier relationships.
- Added unit tests to verify that the repository correctly retrieves the requested tier.