### PR TITLE
[PB-3915]: feat/handle subscription canceled

### DIFF
--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -8,6 +8,8 @@ import { PaymentService } from '../services/payment.service';
 import { AppConfig } from '../config';
 import Stripe from 'stripe';
 import { ObjectStorageService } from '../services/objectStorage.service';
+import { handleCancelPlan } from './utils/handleCancelPlan';
+import { TierNotFoundError, TiersService } from '../services/tiers.service';
 
 function isObjectStorageProduct(meta: Stripe.Metadata): boolean {
   return !!meta && !!meta.type && meta.type === 'object-storage';
@@ -48,12 +50,19 @@ export default async function handleSubscriptionCanceled(
   subscription: Stripe.Subscription,
   cacheService: CacheService,
   objectStorageService: ObjectStorageService,
+  tiersService: TiersService,
   log: FastifyBaseLogger,
   config: AppConfig,
 ): Promise<void> {
+  let email: string | null = '';
   const customerId = subscription.customer as string;
   const productId = subscription.items.data[0].price.product as string;
   const { metadata: productMetadata } = await paymentService.getProduct(productId);
+  const customer = await paymentService.getCustomer(customerId);
+
+  if (!customer.deleted) {
+    email = customer.email;
+  }
 
   if (isObjectStorageProduct(productMetadata)) {
     await handleObjectStorageSubscriptionCancelled(
@@ -76,10 +85,6 @@ export default async function handleSubscriptionCanceled(
     log.error(`Error in handleSubscriptionCanceled after trying to clear ${customerId} subscription`);
   }
 
-  if (productType === UserType.Business) {
-    return usersService.destroyWorkspace(uuid);
-  }
-
   if (hasBoughtALifetime) {
     // This user has switched from a subscription to a lifetime, therefore we do not want to downgrade his space
     // The space should not be set to Free plan.
@@ -87,11 +92,26 @@ export default async function handleSubscriptionCanceled(
   }
 
   try {
-    await updateUserTier(uuid, FREE_INDIVIDUAL_TIER, config);
-  } catch (err) {
-    log.error(`[TIER/SUB_CANCELED] Error while updating user tier: uuid: ${uuid} `);
-    log.error(err);
-  }
+    await handleCancelPlan({
+      customerId,
+      customerEmail: email ?? '',
+      productId,
+      usersService,
+      tiersService,
+      log,
+    });
+  } catch (error) {
+    if (!(error instanceof TierNotFoundError)) {
+      throw error;
+    }
 
-  return storageService.changeStorage(uuid, FREE_PLAN_BYTES_SPACE);
+    try {
+      await updateUserTier(uuid, FREE_INDIVIDUAL_TIER, config);
+    } catch (err) {
+      log.error(`[TIER/SUB_CANCELED] Error while updating user tier: uuid: ${uuid} `);
+      log.error(err);
+    }
+
+    return storageService.changeStorage(uuid, FREE_PLAN_BYTES_SPACE);
+  }
 }

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -67,6 +67,7 @@ export default function (
             event.data.object as Stripe.Subscription,
             cacheService,
             objectStorageService,
+            tiersService,
             fastify.log,
             config,
           );

--- a/src/webhooks/utils/handleOldInvoiceCompletedFlow.ts
+++ b/src/webhooks/utils/handleOldInvoiceCompletedFlow.ts
@@ -73,8 +73,7 @@ export const handleOldInvoiceCompletedFlow = async ({
   try {
     await updateUserTier(userUuid, product.id, config);
   } catch (err) {
-    log.error(`Error while updating user tier: email: ${customer.email}, planId: ${product.id} `);
-    log.error(err);
+    log.error(`Error while updating user tier: email: ${customer.email}, planId: ${product.id}. ERROR: ${err} `);
 
     throw err;
   }

--- a/tests/src/webhooks/handleSubscriptionCanceled.test.ts
+++ b/tests/src/webhooks/handleSubscriptionCanceled.test.ts
@@ -1,0 +1,176 @@
+import Stripe from 'stripe';
+import { CouponsRepository } from '../../../src/core/coupons/CouponsRepository';
+import { UsersCouponsRepository } from '../../../src/core/coupons/UsersCouponsRepository';
+import { DisplayBillingRepository } from '../../../src/core/users/MongoDBDisplayBillingRepository';
+import { TiersRepository } from '../../../src/core/users/MongoDBTiersRepository';
+import { UsersTiersRepository } from '../../../src/core/users/MongoDBUsersTiersRepository';
+import { ProductsRepository } from '../../../src/core/users/ProductsRepository';
+import { UsersRepository } from '../../../src/core/users/UsersRepository';
+import { Bit2MeService } from '../../../src/services/bit2me.service';
+import CacheService from '../../../src/services/cache.service';
+import { PaymentService } from '../../../src/services/payment.service';
+import { StorageService, updateUserTier } from '../../../src/services/storage.service';
+import { TierNotFoundError, TiersService } from '../../../src/services/tiers.service';
+import { UsersService } from '../../../src/services/users.service';
+import { FastifyBaseLogger } from 'fastify';
+import { getCreatedSubscription, getCustomer, getLogger, getProduct, getUser } from '../fixtures';
+import testFactory from '../utils/factory';
+import config from '../../../src/config';
+import axios from 'axios';
+import { ObjectStorageService } from '../../../src/services/objectStorage.service';
+import handleSubscriptionCanceled from '../../../src/webhooks/handleSubscriptionCanceled';
+import { handleCancelPlan } from '../../../src/webhooks/utils/handleCancelPlan';
+import { FREE_INDIVIDUAL_TIER, FREE_PLAN_BYTES_SPACE } from '../../../src/constants';
+
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(),
+  };
+});
+jest.mock('../../../src/services/cache.service', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(),
+  };
+});
+jest.mock('../../../src/webhooks/utils/handleCancelPlan');
+jest.mock('../../../src/services/storage.service', () => {
+  const actualModule = jest.requireActual('../../../src/services/storage.service');
+
+  return {
+    ...actualModule,
+    createOrUpdateUser: jest.fn(),
+    updateUserTier: jest.fn(),
+  };
+});
+
+let paymentService: PaymentService;
+let storageService: StorageService;
+let usersService: UsersService;
+let usersRepository: UsersRepository;
+let displayBillingRepository: DisplayBillingRepository;
+let couponsRepository: CouponsRepository;
+let usersCouponsRepository: UsersCouponsRepository;
+let tiersService: TiersService;
+let tiersRepository: TiersRepository;
+let usersTiersRepository: UsersTiersRepository;
+let productsRepository: ProductsRepository;
+let bit2MeService: Bit2MeService;
+let cacheService: CacheService;
+let stripe: Stripe;
+let objectStorageService: ObjectStorageService;
+let logger: jest.Mocked<FastifyBaseLogger>;
+
+beforeEach(() => {
+  logger = getLogger();
+
+  stripe = new Stripe('mock-key', { apiVersion: '2024-04-10' }) as jest.Mocked<Stripe>;
+  usersRepository = testFactory.getUsersRepositoryForTest();
+  displayBillingRepository = {} as DisplayBillingRepository;
+  couponsRepository = testFactory.getCouponsRepositoryForTest();
+  usersCouponsRepository = testFactory.getUsersCouponsRepositoryForTest();
+  productsRepository = testFactory.getProductsRepositoryForTest();
+  tiersRepository = testFactory.getTiersRepository();
+  usersTiersRepository = testFactory.getUsersTiersRepository();
+
+  cacheService = new CacheService(config);
+  storageService = new StorageService(config, axios);
+  bit2MeService = new Bit2MeService(config, axios);
+  paymentService = new PaymentService(stripe, productsRepository, bit2MeService);
+
+  tiersService = new TiersService(
+    usersService,
+    paymentService,
+    tiersRepository,
+    usersTiersRepository,
+    storageService,
+    config,
+  );
+  usersService = new UsersService(
+    usersRepository,
+    paymentService,
+    displayBillingRepository,
+    couponsRepository,
+    usersCouponsRepository,
+    config,
+    axios,
+  );
+
+  objectStorageService = new ObjectStorageService(paymentService, config, axios);
+
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('Process when a subscription is cancelled', () => {
+  it('When the cancellation of a subscription that have Tier is requested, then it is cancelled successfully', async () => {
+    const mockedUser = getUser();
+    const mockedSubscription = getCreatedSubscription();
+    const mockedProduct = getProduct({});
+    const mockedCustomer = getCustomer();
+
+    const getProductSpy = jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    const getCustomerSPy = jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    const findUserByCustomerIdSpy = jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser);
+    await handleSubscriptionCanceled(
+      storageService,
+      usersService,
+      paymentService,
+      mockedSubscription,
+      cacheService,
+      objectStorageService,
+      tiersService,
+      logger,
+      config,
+    );
+
+    expect(getProductSpy).toHaveBeenCalledWith(mockedSubscription.items.data[0].price.product);
+    expect(getCustomerSPy).toHaveBeenCalledWith(mockedSubscription.customer);
+    expect(findUserByCustomerIdSpy).toHaveBeenCalledWith(mockedSubscription.customer);
+    expect(handleCancelPlan).toHaveBeenCalledWith({
+      customerId: mockedSubscription.customer,
+      customerEmail: mockedCustomer.email,
+      productId: mockedSubscription.items.data[0].price.product,
+      usersService,
+      tiersService,
+      log: logger,
+    });
+  });
+
+  it('When the cancellation of a subscription that does not have a Tier is requested, then should cancel it using the old way', async () => {
+    const mockedUser = getUser();
+    const mockedSubscription = getCreatedSubscription();
+    const mockedProduct = getProduct({});
+    const mockedCustomer = getCustomer();
+    const tierNotFoundError = new TierNotFoundError('Tier not found');
+
+    const getProductSpy = jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    const getCustomerSPy = jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    const findUserByCustomerIdSpy = jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser);
+    const changeStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
+    (handleCancelPlan as jest.Mock).mockRejectedValue(tierNotFoundError);
+
+    await handleSubscriptionCanceled(
+      storageService,
+      usersService,
+      paymentService,
+      mockedSubscription,
+      cacheService,
+      objectStorageService,
+      tiersService,
+      logger,
+      config,
+    );
+
+    expect(getProductSpy).toHaveBeenCalledWith(mockedSubscription.items.data[0].price.product);
+    expect(getCustomerSPy).toHaveBeenCalledWith(mockedSubscription.customer);
+    expect(findUserByCustomerIdSpy).toHaveBeenCalledWith(mockedSubscription.customer);
+    expect(handleCancelPlan).rejects.toThrow(tierNotFoundError);
+    expect(updateUserTier).toHaveBeenCalledWith(mockedUser.uuid, FREE_INDIVIDUAL_TIER, config);
+    expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
+  });
+});


### PR DESCRIPTION
# **What:**
This pull request introduces functionality to remove the association between users and their respective tiers within our local databases. It ensures that upon certain webhook events, users' subscriptions are either canceled or downgraded to the free plan, effectively managing their access levels.

# **Why:**
Implementing this feature is crucial for maintaining accurate user-tier relationships and ensuring that our system reflects the current subscription status of each user. By automating the cancellation or downgrading process through webhook events, we enhance operational efficiency and provide users with a seamless experience that aligns with their subscription choices.