### PR TITLE
[_]: feat/generate-trial-token

### DIFF
--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -451,6 +451,7 @@ export default function (
     );
 
     fastify.post<{
+      Querystring: { trialToken: string };
       Body: {
         customerId: string;
         priceId: string;
@@ -511,8 +512,19 @@ export default function (
           return res.status(403).send();
         }
 
-        if (trialCode !== process.env.PC_CLOUD_TRIAL_CODE) {
-          return res.status(403).send('Invalid trial code');
+        const { trialToken } = req.query;
+
+        if (!trialToken) {
+          return res.status(403).send('Invalid trial token');
+        }
+
+        try {
+          const payload = jwt.verify(trialToken, config.JWT_SECRET) as { trial?: string };
+          if (!payload.trial || payload.trial !== 'pc-cloud-25') {
+            throw new Error('Invalid trial token')
+          }
+        } catch {
+          return res.status(403).send('Invalid trial token');
         }
 
         try {

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -550,6 +550,18 @@ export default function (
       },
     );
 
+    fastify.get<{
+      Querystring: { code: string };
+    }>('/trial-for-subscription', async (req, rep) => {
+      const { code } = req.query;
+      if (!code || code !== process.env.PC_CLOUD_TRIAL_CODE) {
+        return rep.status(400).send();
+      }
+      await assertUser(req, rep, usersService);
+
+      return jwt.sign({ trial: 'pc-cloud-25' }, config.JWT_SECRET)
+    });
+
     fastify.get('/users/exists', async (req, rep) => {
       await assertUser(req, rep, usersService);
 


### PR DESCRIPTION
Enables an endpoint to generate a token to enable subscriptions with trials for the PcComponentes campaign. 