### PR TITLE
[_]: feat/cancelling-subscription-lifetime-logs

### DIFF
--- a/src/webhooks/handleInvoiceCompleted.ts
+++ b/src/webhooks/handleInvoiceCompleted.ts
@@ -132,8 +132,9 @@ export default async function handleInvoiceCompleted(
       const response = await usersService.findUserByEmail(email);
       user = response.data;
     } else {
-      log.error(`Error searching for an user by email in checkout session completed handler, email: ${email}`);
-      log.error(err);
+      log.error(
+        `Error searching for an user by email in checkout session completed handler, email: ${email}. ERROR: ${err}`,
+      );
       throw err;
     }
   }

--- a/src/webhooks/handleLifetimeRefunded.ts
+++ b/src/webhooks/handleLifetimeRefunded.ts
@@ -61,7 +61,6 @@ export default async function handleLifetimeRefunded(
       log.error(
         `[LIFETIME REFUNDED]: Error while updating user tier: uuid: ${uuid}. [ERROR STACK]: ${error.stack ?? error.message} `,
       );
-      throw err;
     }
 
     return storageService.changeStorage(uuid, FREE_PLAN_BYTES_SPACE);

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -1,8 +1,8 @@
 import { UserType } from './../core/users/User';
 import { FastifyBaseLogger, FastifyLoggerInstance } from 'fastify';
-import { FREE_INDIVIDUAL_TIER, FREE_PLAN_BYTES_SPACE } from '../constants';
+import { FREE_PLAN_BYTES_SPACE } from '../constants';
 import CacheService from '../services/cache.service';
-import { StorageService, updateUserTier } from '../services/storage.service';
+import { StorageService } from '../services/storage.service';
 import { UsersService } from '../services/users.service';
 import { PaymentService } from '../services/payment.service';
 import { AppConfig } from '../config';
@@ -79,7 +79,7 @@ export default async function handleSubscriptionCanceled(
 
   const productType = productMetadata?.type === UserType.Business ? UserType.Business : UserType.Individual;
 
-  log.info(`User with customerId ${customerId} found. The uuid of the user is: ${uuid}`);
+  log.info(`User with customerId ${customerId} found. The uuid of the user is: ${uuid} and productId: ${productId}`);
 
   try {
     await cacheService.clearSubscription(customerId, productType);
@@ -107,13 +107,6 @@ export default async function handleSubscriptionCanceled(
     log.error(`[SUB CANCEL/ERROR]: Error canceling tier product. ERROR: ${err.stack ?? err.message}`);
     if (!(error instanceof TierNotFoundError)) {
       throw error;
-    }
-
-    try {
-      await updateUserTier(uuid, FREE_INDIVIDUAL_TIER, config);
-    } catch (err) {
-      log.error(`[TIER/SUB_CANCELED] Error while updating user tier: uuid: ${uuid} `);
-      log.error(err);
     }
 
     return storageService.changeStorage(uuid, FREE_PLAN_BYTES_SPACE);

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -79,6 +79,8 @@ export default async function handleSubscriptionCanceled(
 
   const productType = productMetadata?.type === UserType.Business ? UserType.Business : UserType.Individual;
 
+  log.info(`User with customerId ${customerId} found. The uuid of the user is: ${uuid}`);
+
   try {
     await cacheService.clearSubscription(customerId, productType);
   } catch (err) {
@@ -101,6 +103,8 @@ export default async function handleSubscriptionCanceled(
       log,
     });
   } catch (error) {
+    const err = error as Error;
+    log.error(`[SUB CANCEL/ERROR]: Error canceling tier product. ERROR: ${err.stack ?? err.message}`);
     if (!(error instanceof TierNotFoundError)) {
       throw error;
     }

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -118,7 +118,6 @@ export default async function handleSubscriptionCanceled(
       log.error(
         `[SUB CANCEL/ERROR]: Error while updating user tier: uuid: ${uuid}. [ERROR STACK]: ${error.stack ?? error.message} `,
       );
-      throw err;
     }
 
     return storageService.changeStorage(uuid, FREE_PLAN_BYTES_SPACE);

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -1,8 +1,8 @@
 import { UserType } from './../core/users/User';
 import { FastifyBaseLogger, FastifyLoggerInstance } from 'fastify';
-import { FREE_PLAN_BYTES_SPACE } from '../constants';
+import { FREE_INDIVIDUAL_TIER, FREE_PLAN_BYTES_SPACE } from '../constants';
 import CacheService from '../services/cache.service';
-import { StorageService } from '../services/storage.service';
+import { StorageService, updateUserTier } from '../services/storage.service';
 import { UsersService } from '../services/users.service';
 import { PaymentService } from '../services/payment.service';
 import { AppConfig } from '../config';
@@ -79,7 +79,9 @@ export default async function handleSubscriptionCanceled(
 
   const productType = productMetadata?.type === UserType.Business ? UserType.Business : UserType.Individual;
 
-  log.info(`User with customerId ${customerId} found. The uuid of the user is: ${uuid} and productId: ${productId}`);
+  log.info(
+    `[SUB CANCEL]: User with customerId ${customerId} found. The uuid of the user is: ${uuid} and productId: ${productId}`,
+  );
 
   try {
     await cacheService.clearSubscription(customerId, productType);
@@ -107,6 +109,16 @@ export default async function handleSubscriptionCanceled(
     log.error(`[SUB CANCEL/ERROR]: Error canceling tier product. ERROR: ${err.stack ?? err.message}`);
     if (!(error instanceof TierNotFoundError)) {
       throw error;
+    }
+
+    try {
+      await updateUserTier(uuid, FREE_INDIVIDUAL_TIER, config);
+    } catch (err) {
+      const error = err as Error;
+      log.error(
+        `[SUB CANCEL/ERROR]: Error while updating user tier: uuid: ${uuid}. [ERROR STACK]: ${error.stack ?? error.message} `,
+      );
+      throw err;
     }
 
     return storageService.changeStorage(uuid, FREE_PLAN_BYTES_SPACE);

--- a/src/webhooks/utils/handleCancelPlan.ts
+++ b/src/webhooks/utils/handleCancelPlan.ts
@@ -25,17 +25,19 @@ export const handleCancelPlan = async ({
   const { id: userId } = user;
   const tier = await tiersService.getTierProductsByProductsId(productId);
 
-  log.info(`The user with id ${userId} exists, and the product with id ${tier.id} also exists.`);
+  log.info(`[CANCEL PLAN HANDLER]: The user with id ${userId} exists, and the product with id ${tier.id} also exists.`);
 
   await usersService.updateUser(customerId, { lifetime: false });
 
-  log.info(`THe user data for the customer ${userId} has been downgraded in handleCancelPlan`);
+  log.info(`[CANCEL PLAN HANDLER]: THe user data for the customer ${userId} has been downgraded in handleCancelPlan`);
 
   await tiersService.removeTier({ ...user, email: customerEmail }, productId, log);
 
-  log.info(`The tier for the user ${userId} has been removed`);
+  log.info(`[CANCEL PLAN HANDLER]: The tier for the user ${userId} has been removed`);
 
   await tiersService.deleteTierFromUser(userId, tier.id);
 
-  log.info(`The user-tier relationship using the user id ${userId} and tier id ${tier.id} has been deleted`);
+  log.info(
+    `[CANCEL PLAN HANDLER]: The user-tier relationship using the user id ${userId} and tier id ${tier.id} has been deleted`,
+  );
 };

--- a/src/webhooks/utils/handleCancelPlan.ts
+++ b/src/webhooks/utils/handleCancelPlan.ts
@@ -25,8 +25,17 @@ export const handleCancelPlan = async ({
   const { id: userId } = user;
   const tier = await tiersService.getTierProductsByProductsId(productId);
 
+  log.info(`The user with id ${userId} exists, and the product with id ${tier.id} also exists.`);
+
   await usersService.updateUser(customerId, { lifetime: false });
 
+  log.info(`THe user data for the customer ${userId} has been downgraded in handleCancelPlan`);
+
   await tiersService.removeTier({ ...user, email: customerEmail }, productId, log);
+
+  log.info(`The tier for the user ${userId} has been removed`);
+
   await tiersService.deleteTierFromUser(userId, tier.id);
+
+  log.info(`The user-tier relationship using the user id ${userId} and tier id ${tier.id} has been deleted`);
 };


### PR DESCRIPTION
This PR implements logs to track flows when cancelling a subscription/lifetime. With these logs, we can keep track of when a user cancels a plan.