### PR TITLE
[PB-3908]: feat/apply stack of lifetime storage

### DIFF
--- a/src/services/tiers.service.ts
+++ b/src/services/tiers.service.ts
@@ -156,6 +156,7 @@ export class TiersService {
     customer: Stripe.Customer,
     amountOfSeats: Stripe.InvoiceLineItem['quantity'],
     productId: string,
+    log: FastifyBaseLogger,
     alreadyEnabledServices?: Service[],
   ): Promise<void> {
     const tier = await this.tiersRepository.findByProductId({ productId });
@@ -173,7 +174,7 @@ export class TiersService {
 
       switch (s) {
         case Service.Drive:
-          await this.applyDriveFeatures(userWithEmail, customer, amountOfSeats, tier);
+          await this.applyDriveFeatures(userWithEmail, customer, amountOfSeats, tier, log);
           break;
         case Service.Vpn:
           await this.applyVpnFeatures(userWithEmail, tier);
@@ -220,6 +221,7 @@ export class TiersService {
     customer: Stripe.Customer,
     subscriptionSeats: Stripe.InvoiceLineItem['quantity'],
     tier: Tier,
+    log: FastifyBaseLogger,
   ): Promise<void> {
     const features = tier.featuresPerService[Service.Drive];
 
@@ -233,7 +235,13 @@ export class TiersService {
 
       try {
         await this.usersService.updateWorkspaceStorage(userWithEmail.uuid, Number(maxSpaceBytes), subscriptionSeats);
+        log.info(`[DRIVE/WORKSPACES]: The workspace for user ${userWithEmail.uuid} has been updated`);
       } catch (err) {
+        log.info(
+          `[DRIVE/WORKSPACES]: User with customer Id: ${customer.id} - uuid: ${userWithEmail.uuid} - email: ${
+            customer.email
+          } does not have a workspace. Creating a new one...`,
+        );
         await this.usersService.initializeWorkspace(userWithEmail.uuid, {
           newStorageBytes: Number(maxSpaceBytes),
           seats: subscriptionSeats,

--- a/src/webhooks/handleInvoiceCompleted.ts
+++ b/src/webhooks/handleInvoiceCompleted.ts
@@ -111,6 +111,9 @@ export default async function handleInvoiceCompleted(
     const shouldCancelCurrentActiveSubscription = isLifetimePlan && hasIndividualActiveSubscription;
 
     if (shouldCancelCurrentActiveSubscription) {
+      log.info(
+        `User with customer id: ${customer.id} amd email ${customer.email} has an active individual subscription and is buying a lifetime plan. Cancelling individual plan`,
+      );
       await paymentService.cancelSubscription(hasIndividualActiveSubscription.id);
     }
   } catch (error) {

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -89,7 +89,7 @@ export default async function handleSubscriptionCanceled(
     log.error(`Error in handleSubscriptionCanceled after trying to clear ${customerId} subscription`);
   }
 
-  if (hasBoughtALifetime) {
+  if (hasBoughtALifetime && productType === UserType.Individual) {
     log.info(`User with uuid ${uuid} has a lifetime subscription. No need to downgrade the user.`);
     // This user has switched from a subscription to a lifetime, therefore we do not want to downgrade his space
     // The space should not be set to Free plan.

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -90,6 +90,7 @@ export default async function handleSubscriptionCanceled(
   }
 
   if (hasBoughtALifetime) {
+    log.info(`User with uuid ${uuid} has a lifetime subscription. No need to downgrade the user.`);
     // This user has switched from a subscription to a lifetime, therefore we do not want to downgrade his space
     // The space should not be set to Free plan.
     return;

--- a/src/webhooks/utils/handleUserFeatures.ts
+++ b/src/webhooks/utils/handleUserFeatures.ts
@@ -80,7 +80,7 @@ export const handleUserFeatures = async ({
 
     const oldProductId = latestInvoice.product as string;
     const existingTier =
-      oldLifetimeTier ?? existingTiersForUser.find((existingUserTier) => existingUserTier.productId === oldProductId);
+      existingTiersForUser.find((existingUserTier) => existingUserTier.productId === oldProductId) ?? oldLifetimeTier;
 
     if (!existingTier) {
       throw new InvoiceNotFoundError(

--- a/src/webhooks/utils/handleUserFeatures.ts
+++ b/src/webhooks/utils/handleUserFeatures.ts
@@ -56,7 +56,9 @@ export const handleUserFeatures = async ({
     );
 
     if (isLifetimeStackTry && oldLifetimeTier) {
-      logger.info(`User with uuid ${user.uuid} has a lifetime. Updating user and tier...`);
+      logger.info(
+        `User with uuid ${user.uuid} has a lifetime and purchased the tier with id ${newTierId}. Updating user and tier...`,
+      );
       handleStackLifetimeStorage({
         customer,
         logger,

--- a/src/webhooks/utils/handleUserFeatures.ts
+++ b/src/webhooks/utils/handleUserFeatures.ts
@@ -136,7 +136,7 @@ export const handleUserFeatures = async ({
       logger.warn(`${error.constructor.name} -> Inserting new tier for user uuid="${user.uuid}"`);
       const existingUser = await usersService.findUserByUuid(user.uuid);
       const isLifetimeStackTry = tier.billingType === 'lifetime' && existingUser.lifetime;
-      const excludedServices = isLifetimeStackTry ? [Service.Drive] : [];
+      const excludedServices = isLifetimeStackTry ? [Service.Drive] : undefined;
 
       const isLifetimePlan = isBusinessPlan ? existingUser.lifetime : isLifetimeCurrentSub;
 

--- a/src/webhooks/utils/handleUserFeatures.ts
+++ b/src/webhooks/utils/handleUserFeatures.ts
@@ -46,7 +46,7 @@ export const handleUserFeatures = async ({
 
   try {
     const existingUser = await usersService.findUserByUuid(user.uuid);
-    const isLifetimeStackTry = tier.billingType === 'lifetime' && existingUser.lifetime;
+    const isLifetimeStackTry = tier.billingType === 'lifetime' && existingUser.lifetime && !isBusinessPlan;
 
     const isLifetimePlan = isBusinessPlan ? existingUser.lifetime : isLifetimeCurrentSub;
 

--- a/src/webhooks/utils/handleUserFeatures.ts
+++ b/src/webhooks/utils/handleUserFeatures.ts
@@ -97,8 +97,7 @@ export const handleUserFeatures = async ({
     }
 
     const oldProductId = latestInvoice.product as string;
-    const existingTier =
-      existingTiersForUser.find((existingUserTier) => existingUserTier.productId === oldProductId) ?? oldLifetimeTier;
+    const existingTier = existingTiersForUser.find((existingUserTier) => existingUserTier.productId === oldProductId);
 
     if (!existingTier) {
       throw new InvoiceNotFoundError(

--- a/src/webhooks/utils/handleUserFeatures.ts
+++ b/src/webhooks/utils/handleUserFeatures.ts
@@ -46,7 +46,7 @@ export const handleUserFeatures = async ({
 
   try {
     const existingUser = await usersService.findUserByUuid(user.uuid);
-    const isLifetimeStackTry = tier.billingType === 'lifetime' && existingUser.lifetime && !isBusinessPlan;
+    const isStackingLifetimes = tier.billingType === 'lifetime' && existingUser.lifetime && !isBusinessPlan;
 
     const isLifetimePlan = isBusinessPlan ? existingUser.lifetime : isLifetimeCurrentSub;
 
@@ -55,7 +55,7 @@ export const handleUserFeatures = async ({
       (existingUserTier) => existingUserTier.billingType === 'lifetime',
     );
 
-    if (isLifetimeStackTry && oldLifetimeTier) {
+    if (isStackingLifetimes && oldLifetimeTier) {
       logger.info(
         `User with uuid ${user.uuid} has a lifetime and purchased the tier with id ${newTierId}. Updating user and tier...`,
       );
@@ -135,12 +135,12 @@ export const handleUserFeatures = async ({
     } else if (error instanceof TierNotFoundError || error instanceof InvoiceNotFoundError) {
       logger.warn(`${error.constructor.name} -> Inserting new tier for user uuid="${user.uuid}"`);
       const existingUser = await usersService.findUserByUuid(user.uuid);
-      const isLifetimeStackTry = tier.billingType === 'lifetime' && existingUser.lifetime;
-      const excludedServices = isLifetimeStackTry ? [Service.Drive] : undefined;
+      const isStackingLifetimes = tier.billingType === 'lifetime' && existingUser.lifetime;
+      const excludedServices = isStackingLifetimes ? [Service.Drive] : undefined;
 
       const isLifetimePlan = isBusinessPlan ? existingUser.lifetime : isLifetimeCurrentSub;
 
-      if (isLifetimeStackTry) {
+      if (isStackingLifetimes) {
         logger.info(
           `User with uuid ${user.uuid} has a lifetime and purchased the tier with id ${newTierId}. Updating user and tier...`,
         );

--- a/tests/src/webhooks/utils/handleCancelPlan.test.ts
+++ b/tests/src/webhooks/utils/handleCancelPlan.test.ts
@@ -77,6 +77,7 @@ describe('Handling canceled plans and refunded lifetimes', () => {
     jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedTier);
     const updateUserSpy = jest.spyOn(usersService, 'updateUser').mockImplementation(voidPromise);
     const removeTierSpy = jest.spyOn(tiersService, 'removeTier').mockImplementation(voidPromise);
+    const userTiersSpy = jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
     const deleteTierFromUserSpy = jest.spyOn(tiersService, 'deleteTierFromUser').mockImplementation(voidPromise);
 
     await handleCancelPlan({
@@ -94,6 +95,7 @@ describe('Handling canceled plans and refunded lifetimes', () => {
       mockedTier.productId,
       log,
     );
+    expect(userTiersSpy).toHaveBeenCalledWith(mockedUser.id);
     expect(deleteTierFromUserSpy).toHaveBeenCalledWith(mockedUser.id, mockedTier.id);
   });
 
@@ -101,7 +103,7 @@ describe('Handling canceled plans and refunded lifetimes', () => {
     const mockedCustomer = getCustomer();
     const log = getLogger();
     const mockedUser = getUser({ customerId: mockedCustomer.id, lifetime: true });
-    const mockedTier = newTier();
+    const mockedTier = newTier({ billingType: 'lifetime' });
 
     jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser);
     jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedTier);
@@ -112,6 +114,7 @@ describe('Handling canceled plans and refunded lifetimes', () => {
       return Promise.resolve();
     });
     const removeTierSpy = jest.spyOn(tiersService, 'removeTier').mockImplementation(voidPromise);
+    const userTiersSpy = jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
     const deleteTierFromUserSpy = jest.spyOn(tiersService, 'deleteTierFromUser').mockImplementation(voidPromise);
 
     await handleCancelPlan({
@@ -130,6 +133,7 @@ describe('Handling canceled plans and refunded lifetimes', () => {
       mockedTier.productId,
       log,
     );
+    expect(userTiersSpy).toHaveBeenCalledWith(mockedUser.id);
     expect(deleteTierFromUserSpy).toHaveBeenCalledWith(mockedUser.id, mockedTier.id);
   });
 });

--- a/tests/src/webhooks/utils/handleUserFeatures.test.ts
+++ b/tests/src/webhooks/utils/handleUserFeatures.test.ts
@@ -19,6 +19,7 @@ import { User } from '../../../../src/core/users/User';
 import { StorageService } from '../../../../src/services/storage.service';
 import { handleStackLifetimeStorage } from '../../../../src/webhooks/utils/handleStackLifetimeStorage';
 import { Service, Tier } from '../../../../src/core/users/Tier';
+import { FastifyBaseLogger } from 'fastify';
 
 jest.mock('../../../../src/webhooks/utils/handleStackLifetimeStorage');
 
@@ -39,6 +40,7 @@ let mockedTier: Tier;
 let mockedUser: User & { email: string };
 let mockedCustomer: Stripe.Customer;
 let mockedPurchasedItem: Stripe.InvoiceLineItem;
+let logger: jest.Mocked<FastifyBaseLogger>;
 
 describe('Create or update user when after successful payment', () => {
   beforeEach(() => {
@@ -46,6 +48,7 @@ describe('Create or update user when after successful payment', () => {
       ...getUser(),
       email: 'test@example.com',
     } as User & { email: string };
+    logger = getLogger();
     mockedTier = newTier();
     mockedCustomer = getCustomer();
     mockedPurchasedItem = getInvoice().lines.data[0];
@@ -89,7 +92,7 @@ describe('Create or update user when after successful payment', () => {
       purchasedItem: mockedPurchasedItem,
       paymentService,
       usersService,
-      logger: getLogger(),
+      logger,
       isLifetimeCurrentSub: false,
       customer: mockedCustomer,
       tiersService,
@@ -129,6 +132,7 @@ describe('Create or update user when after successful payment', () => {
       mockedCustomer,
       mockedPurchasedItem.quantity,
       (mockedPurchasedItem.price?.product as Stripe.Product).id,
+      logger,
       undefined,
     );
     expect(spyUpdate).not.toHaveBeenCalled();
@@ -169,6 +173,7 @@ describe('Create or update user when after successful payment', () => {
       mockedCustomer,
       mockedPurchasedItem.quantity,
       (mockedPurchasedItem.price?.product as Stripe.Product).id,
+      logger,
       undefined,
     );
     expect(spyUpdateUser).toHaveBeenCalledWith(mockedCustomer.id, { lifetime: false });
@@ -211,6 +216,7 @@ describe('Create or update user when after successful payment', () => {
       mockedCustomer,
       mockedPurchasedItem.quantity,
       (mockedPurchasedItem.price?.product as Stripe.Product).id,
+      logger,
     );
     expect(spyInsert).not.toHaveBeenCalled();
   });
@@ -239,6 +245,7 @@ describe('Create or update user when after successful payment', () => {
       mockedCustomer,
       mockedPurchasedItem.quantity,
       (mockedPurchasedItem.price?.product as Stripe.Product).id,
+      logger,
     );
     expect(spyUpdate).not.toHaveBeenCalled();
   });
@@ -309,6 +316,7 @@ describe('Create or update user when after successful payment', () => {
         mockedCustomer,
         mockedPurchasedItem.quantity,
         (mockedPurchasedItem.price?.product as Stripe.Product).id,
+        logger,
         [Service.Drive],
       );
       expect(spyUpdate).not.toHaveBeenCalled();
@@ -361,6 +369,7 @@ describe('Create or update user when after successful payment', () => {
         defaultProps.customer,
         defaultProps.purchasedItem.quantity,
         newLifetimeTier.productId,
+        logger,
         [Service.Drive],
       );
 

--- a/tests/src/webhooks/utils/handleUserFeatures.test.ts
+++ b/tests/src/webhooks/utils/handleUserFeatures.test.ts
@@ -314,7 +314,7 @@ describe('Create or update user when after successful payment', () => {
       expect(spyUpdate).not.toHaveBeenCalled();
     });
 
-    it('When user already has a new lifetime plan and tier and purchases a higher tier, then the space is stacked, the new tier is applied and user-tier relationship is updated', async () => {
+    it('When user already has a new lifetime plan and tier and purchases a higher tier,  then the storage should be stacked, the tier applied and the user-tier relationship should be updated', async () => {
       const oldLifetimeTier = {
         ...mockedTier,
         id: 'old-lifetime-tier-id',


### PR DESCRIPTION
## **What**
This PR handles stacking lifetimes cases - when the user purchases a plan (`invoice.payment-succeeded`) and when a lifetime is refunded (`charge.refund`).
## **Why**
We need to handle the stack of storage when the lifetime plan is paid. Also, we need to reset the user tier to free when the last lifetime is refunded.