### PR TITLE
[_]: feat/return the lifetime product id the user has

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -44,7 +44,7 @@ export async function buildApp(
     logger: envToLogger[config.NODE_ENV] ?? true,
   });
 
-  fastify.register(controller(paymentService, usersService, config, cacheService, licenseCodesService));
+  fastify.register(controller(paymentService, usersService, config, cacheService, licenseCodesService, tiersService));
   fastify.register(businessController(paymentService, usersService, config), { prefix: '/business' });
   fastify.register(productsController(tiersService, usersService, config), { prefix: '/products' });
   fastify.register(controllerMigration(paymentService, usersService, config));

--- a/src/core/users/DisplayPrice.ts
+++ b/src/core/users/DisplayPrice.ts
@@ -1,5 +1,6 @@
 export interface DisplayPrice {
   id: string;
+  productId?: string;
   bytes: number;
   interval: 'year' | 'month' | 'lifetime';
   amount: number;

--- a/src/core/users/User.ts
+++ b/src/core/users/User.ts
@@ -14,7 +14,8 @@ export enum UserType {
 }
 
 export type UserSubscription =
-  | { type: 'free' | 'lifetime' }
+  | { type: 'free' }
+  | { type: 'lifetime'; productId?: string }
   | {
       type: 'subscription';
       subscriptionId: string;
@@ -24,7 +25,7 @@ export type UserSubscription =
       interval: 'year' | 'month';
       nextPayment: number;
       priceId: string;
-      planId?: string;
+      productId?: string;
       userType?: UserType;
       plan: PlanSubscription;
     };

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -939,7 +939,7 @@ export class PaymentService {
       nextPayment: subscription.current_period_end,
       amountAfterCoupon: upcomingInvoice.total,
       priceId: price.id,
-      planId: price?.product as string,
+      productId: price?.product as string,
       userType,
       plan,
     };
@@ -967,6 +967,7 @@ export class PaymentService {
       .map((price) => {
         return {
           id: price.id,
+          productId: (price.product as Stripe.Product).id,
           currency: currencyValue,
           amount: price.currency_options![currencyValue].unit_amount as number,
           bytes: parseInt(price.metadata.maxSpaceBytes),

--- a/tests/src/controller/payments.controller.test.ts
+++ b/tests/src/controller/payments.controller.test.ts
@@ -1,12 +1,25 @@
 import { FastifyInstance } from 'fastify';
 import jwt from 'jsonwebtoken';
-import { getPrice, getPrices, getUniqueCodes, getUser, getValidToken } from '../fixtures';
+import { getPrice, getPrices, getUniqueCodes, getUser, getValidToken, newTier } from '../fixtures';
 import { closeServerAndDatabase, initializeServerAndDatabase } from '../utils/initializeServer';
 import { getUserStorage } from '../../../src/services/storage.service';
 import { PaymentService } from '../../../src/services/payment.service';
 import config from '../../../src/config';
 import { HUNDRED_TB } from '../../../src/constants';
+import { assertUser } from '../../../src/utils/assertUser';
+import { TierNotFoundError, TiersService } from '../../../src/services/tiers.service';
+import CacheService from '../../../src/services/cache.service';
 
+jest.mock('ioredis', () => {
+  return jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1),
+    quit: jest.fn().mockResolvedValue(undefined), // Para cerrar la conexión correctamente
+  }));
+});
+
+jest.mock('../../../src/utils/assertUser');
 jest.mock('../../../src/services/storage.service', () => {
   const actualModule = jest.requireActual('../../../src/services/storage.service');
 
@@ -127,107 +140,162 @@ describe('Payment controller e2e tests', () => {
         expect(response.statusCode).toBe(404);
       });
     });
+  });
 
-    describe('Create a payment intent for one time payment products (lifetimes)', () => {
-      it('When the user attempts to purchase a lifetime plan and is a free user, then the user should be allowed to purchase the product', async () => {
-        const mockedUser = getUser();
-        const mockedPrice = getPrice();
-        const mockedToken = getValidToken(mockedUser.uuid);
-        const paymentIntentResponse = {
-          clientSecret: 'client-secret',
-          id: 'client-secret-id',
-        };
+  describe('Create a payment intent for one time payment products (lifetimes)', () => {
+    it('When the user attempts to purchase a lifetime plan and is a free user, then the user should be allowed to purchase the product', async () => {
+      const mockedUser = getUser();
+      const mockedPrice = getPrice();
+      const mockedToken = getValidToken(mockedUser.uuid);
+      const paymentIntentResponse = {
+        clientSecret: 'client-secret',
+        id: 'client-secret-id',
+      };
 
-        jest.spyOn(PaymentService.prototype, 'getPlanById').mockResolvedValue({
-          selectedPlan: {
-            amount: Number(mockedPrice.unit_amount),
-            bytes: 10,
-            currency: mockedPrice.currency,
-            decimalAmount: Number(mockedPrice.unit_amount_decimal),
-            id: mockedPrice.id,
-            interval: 'lifetime',
-          },
-        });
-        (getUserStorage as jest.Mock).mockResolvedValue(Promise.resolve({ currentMaxSpaceBytes: 1024 }));
-        jest.spyOn(PaymentService.prototype, 'createPaymentIntent').mockResolvedValue(paymentIntentResponse);
-
-        const token = jwt.sign(
-          {
-            customerId: mockedUser.customerId,
-          },
-          config.JWT_SECRET,
-        );
-
-        const mockedQuery = {
-          customerId: mockedUser.customerId,
-          planId: mockedPrice.id,
-          amount: mockedPrice.unit_amount !== null ? String(mockedPrice.unit_amount) : '',
-          token: token,
+      jest.spyOn(PaymentService.prototype, 'getPlanById').mockResolvedValue({
+        selectedPlan: {
+          amount: Number(mockedPrice.unit_amount),
+          bytes: 10,
           currency: mockedPrice.currency,
-        };
+          decimalAmount: Number(mockedPrice.unit_amount_decimal),
+          id: mockedPrice.id,
+          interval: 'lifetime',
+        },
+      });
+      (getUserStorage as jest.Mock).mockResolvedValue(Promise.resolve({ currentMaxSpaceBytes: 1024 }));
+      jest.spyOn(PaymentService.prototype, 'createPaymentIntent').mockResolvedValue(paymentIntentResponse);
 
-        const response = await app.inject({
-          method: 'GET',
-          path: '/payment-intent',
-          headers: {
-            authorization: `Bearer ${mockedToken}`,
-          },
-          query: mockedQuery,
-        });
+      const token = jwt.sign(
+        {
+          customerId: mockedUser.customerId,
+        },
+        config.JWT_SECRET,
+      );
 
-        const responseBody = JSON.parse(response.body);
+      const mockedQuery = {
+        customerId: mockedUser.customerId,
+        planId: mockedPrice.id,
+        amount: mockedPrice.unit_amount !== null ? String(mockedPrice.unit_amount) : '',
+        token: token,
+        currency: mockedPrice.currency,
+      };
 
-        expect(response.statusCode).toBe(200);
-        expect(responseBody).toStrictEqual(paymentIntentResponse);
+      const response = await app.inject({
+        method: 'GET',
+        path: '/payment-intent',
+        headers: {
+          authorization: `Bearer ${mockedToken}`,
+        },
+        query: mockedQuery,
       });
 
-      it('When the user is close to the storage limit (100TB) and the product to purchase passes it, then an error indicating so is thrown', async () => {
-        const mockedUser = getUser();
-        const mockedPrice = getPrice();
-        const mockedToken = getValidToken(mockedUser.uuid);
-        const paymentIntentResponse = {
-          clientSecret: 'client-secret',
-          id: 'client-secret-id',
-        };
+      const responseBody = JSON.parse(response.body);
 
-        jest.spyOn(PaymentService.prototype, 'getPlanById').mockResolvedValue({
-          selectedPlan: {
-            amount: Number(mockedPrice.unit_amount),
-            bytes: 10,
-            currency: mockedPrice.currency,
-            decimalAmount: Number(mockedPrice.unit_amount_decimal),
-            id: mockedPrice.id,
-            interval: 'lifetime',
-          },
-        });
-        (getUserStorage as jest.Mock).mockResolvedValue(Promise.resolve({ currentMaxSpaceBytes: HUNDRED_TB }));
-        jest.spyOn(PaymentService.prototype, 'createPaymentIntent').mockResolvedValue(paymentIntentResponse);
+      expect(response.statusCode).toBe(200);
+      expect(responseBody).toStrictEqual(paymentIntentResponse);
+    });
 
-        const token = jwt.sign(
-          {
-            customerId: mockedUser.customerId,
-          },
-          config.JWT_SECRET,
-        );
+    it('When the user is close to the storage limit (100TB) and the product to purchase passes it, then an error indicating so is thrown', async () => {
+      const mockedUser = getUser();
+      const mockedPrice = getPrice();
+      const mockedToken = getValidToken(mockedUser.uuid);
+      const paymentIntentResponse = {
+        clientSecret: 'client-secret',
+        id: 'client-secret-id',
+      };
 
-        const mockedQuery = {
-          customerId: mockedUser.customerId,
-          planId: mockedPrice.id,
-          amount: mockedPrice.unit_amount !== null ? String(mockedPrice.unit_amount) : '',
-          token: token,
+      jest.spyOn(PaymentService.prototype, 'getPlanById').mockResolvedValue({
+        selectedPlan: {
+          amount: Number(mockedPrice.unit_amount),
+          bytes: 10,
           currency: mockedPrice.currency,
-        };
+          decimalAmount: Number(mockedPrice.unit_amount_decimal),
+          id: mockedPrice.id,
+          interval: 'lifetime',
+        },
+      });
+      (getUserStorage as jest.Mock).mockResolvedValue(Promise.resolve({ currentMaxSpaceBytes: HUNDRED_TB }));
+      jest.spyOn(PaymentService.prototype, 'createPaymentIntent').mockResolvedValue(paymentIntentResponse);
+
+      const token = jwt.sign(
+        {
+          customerId: mockedUser.customerId,
+        },
+        config.JWT_SECRET,
+      );
+
+      const mockedQuery = {
+        customerId: mockedUser.customerId,
+        planId: mockedPrice.id,
+        amount: mockedPrice.unit_amount !== null ? String(mockedPrice.unit_amount) : '',
+        token: token,
+        currency: mockedPrice.currency,
+      };
+
+      const response = await app.inject({
+        method: 'GET',
+        path: '/payment-intent',
+        headers: {
+          authorization: `Bearer ${mockedToken}`,
+        },
+        query: mockedQuery,
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe('Get the user subscription', () => {
+    describe('The user has a lifetime', () => {
+      it('When the user has a Tier, then the type of subscription is lifetime and the product ID of the tier is returned', async () => {
+        const mockedUser = getUser({ lifetime: true });
+        const mockedToken = getValidToken(mockedUser.uuid);
+        const mockedTier = newTier({ billingType: 'lifetime' });
+        (assertUser as jest.Mock).mockResolvedValue(mockedUser);
+        jest.spyOn(CacheService.prototype, 'getSubscription').mockResolvedValue(null);
+        jest.spyOn(TiersService.prototype, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
 
         const response = await app.inject({
           method: 'GET',
-          path: '/payment-intent',
+          path: '/subscriptions',
           headers: {
             authorization: `Bearer ${mockedToken}`,
           },
-          query: mockedQuery,
         });
 
-        expect(response.statusCode).toBe(400);
+        const responseBody = response.json();
+
+        expect(response.statusCode).toBe(200);
+        expect(responseBody).toStrictEqual({
+          type: 'lifetime',
+          productId: mockedTier.productId,
+        });
+      });
+
+      it('When the user does not have a Tier, then the type of subscription is lifetime and the product Id is not returned', async () => {
+        const mockedUser = getUser({ lifetime: true });
+        const mockedToken = getValidToken(mockedUser.uuid);
+
+        (assertUser as jest.Mock).mockResolvedValue(mockedUser);
+        jest.spyOn(CacheService.prototype, 'getSubscription').mockResolvedValue(null);
+        jest
+          .spyOn(TiersService.prototype, 'getTiersProductsByUserId')
+          .mockRejectedValue(new TierNotFoundError('Tier not found'));
+
+        const response = await app.inject({
+          method: 'GET',
+          path: '/subscriptions',
+          headers: {
+            authorization: `Bearer ${mockedToken}`,
+          },
+        });
+
+        const responseBody = response.json();
+
+        expect(response.statusCode).toBe(200);
+        expect(responseBody).toStrictEqual({
+          type: 'lifetime',
+        });
       });
     });
   });


### PR DESCRIPTION
This PR returns the product ID of the assigned Tier, both for subscriptions and lifetime. In this way, we can identify which product/tier the user has at any given moment. It is useful especially for Current tagging in the app web, for example.