### PR TITLE
[_]: fix/backups for all lifetime and subscriptions

### DIFF
--- a/src/services/tiers.service.ts
+++ b/src/services/tiers.service.ts
@@ -120,8 +120,9 @@ export class TiersService {
     const activeUserSubscription = userSubscriptions.find(
       (subscription) => subscription.status === 'active' || subscription.status === 'trialing',
     );
+    const hasActiveSubscription = !!activeUserSubscription;
 
-    if (!activeUserSubscription && !isLifetime) {
+    if (!hasActiveSubscription && !isLifetime) {
       throw new NotFoundSubscriptionError('User has no active subscriptions');
     }
 
@@ -146,7 +147,7 @@ export class TiersService {
     return {
       featuresPerService: {
         antivirus: hasToolsAccess,
-        backups: hasToolsAccess,
+        backups: isLifetime || hasActiveSubscription,
       },
     };
   }


### PR DESCRIPTION
This PR modifies the `GET /products` endpoint to return `backups = true` for users who have any type of subscription or lifetime (old or new product).