### PR TITLE
[PB-4137]: feat/get higher tier available for user

### DIFF
--- a/fastify-jwt.d.ts
+++ b/fastify-jwt.d.ts
@@ -6,10 +6,11 @@ declare module '@fastify/jwt' {
       payload: {
         email: string;
         uuid: string;
+        ownerId?: string[];
         name: string;
         lastname: string;
         username: string;
-        sharedWorkspace: boolean,
+        sharedWorkspace: boolean;
         networkCredentials: {
           user: string;
           pass: string;

--- a/fastify-jwt.d.ts
+++ b/fastify-jwt.d.ts
@@ -6,7 +6,9 @@ declare module '@fastify/jwt' {
       payload: {
         email: string;
         uuid: string;
-        ownerId?: string[];
+        workspaces: {
+          owners: string[];
+        };
         name: string;
         lastname: string;
         username: string;

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import webhook from './webhooks';
 import { LicenseCodesService } from './services/licenseCodes.service';
 import { ObjectStorageService } from './services/objectStorage.service';
 import { TiersService } from './services/tiers.service';
+import { ProductsService } from './services/products.service';
 
 const envToLogger = {
   development: {
@@ -37,6 +38,7 @@ export async function buildApp(
   tiersService: TiersService,
   licenseCodesService: LicenseCodesService,
   objectStorageService: ObjectStorageService,
+  productsService: ProductsService,
   stripe: Stripe,
   config: AppConfig,
 ): Promise<FastifyInstance> {
@@ -46,7 +48,7 @@ export async function buildApp(
 
   fastify.register(controller(paymentService, usersService, config, cacheService, licenseCodesService, tiersService));
   fastify.register(businessController(paymentService, usersService, config), { prefix: '/business' });
-  fastify.register(productsController(tiersService, usersService, config), { prefix: '/products' });
+  fastify.register(productsController(tiersService, usersService, productsService, config), { prefix: '/products' });
   fastify.register(controllerMigration(paymentService, usersService, config));
 
   fastify.register(

--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -67,7 +67,7 @@ export default function (
         const higherTier = await productsService.findHigherTierForUser({
           userUuid,
           ownersId,
-          subscriptionType: UserType.Business,
+          subscriptionType: UserType.Individual,
         });
 
         return rep.status(200).send(higherTier);

--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -6,7 +6,7 @@ import { assertUser } from '../utils/assertUser';
 import fastifyJwt from '@fastify/jwt';
 import fastifyLimit from '@fastify/rate-limit';
 import { TierNotFoundError, TiersService } from '../services/tiers.service';
-import { User } from '../core/users/User';
+import { User, UserType } from '../core/users/User';
 import { ProductsService } from '../services/products.service';
 
 export default function (
@@ -61,10 +61,14 @@ export default function (
 
     fastify.get('/tier', async (req: FastifyRequest, rep: FastifyReply) => {
       const userUuid = req.user.payload.uuid;
-      const ownerId = req.user.payload.ownerId;
+      const ownersId = req.user.payload.workspaces.owners;
 
       try {
-        const higherTier = await productsService.findHigherTierForUser({ userUuid, ownerId });
+        const higherTier = await productsService.findHigherTierForUser({
+          userUuid,
+          ownersId,
+          subscriptionType: UserType.Business,
+        });
 
         return rep.status(200).send(higherTier);
       } catch (error) {

--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -71,7 +71,7 @@ export default function (
       };
     }>('/tier', async (req, rep) => {
       const userUuid = req.user.payload.uuid;
-      const ownersId = req.user.payload.workspaces.owners;
+      const ownersId = req.user.payload.workspaces?.owners ?? [];
       const subscriptionType = (req.query.subscriptionType as UserType) || UserType.Individual;
 
       try {

--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -76,7 +76,7 @@ export default function (
       const subscriptionType = (req.query.subscriptionType as UserType) || UserType.Individual;
 
       try {
-        const higherTier = await productsService.findHigherTierForUser({
+        const higherTier = await productsService.getApplicableTierForUser({
           userUuid,
           ownersId,
           subscriptionType,

--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -60,6 +60,7 @@ export default function (
     );
 
     fastify.get('/tier', async (req: FastifyRequest, rep: FastifyReply) => {
+      console.log(req.user);
       const userUuid = req.user.payload.uuid;
       const ownersId = req.user.payload.workspaces.owners;
 
@@ -73,7 +74,7 @@ export default function (
         return rep.status(200).send(higherTier);
       } catch (error) {
         req.log.error(`[TIER PRODUCT/ERROR]: ${(error as Error).message || error} for user ${userUuid}`);
-        if (error instanceof TierNotFoundError) {
+        if (error instanceof UserNotFoundError || error instanceof TierNotFoundError) {
           const freeTier = await tiersService.getTierProductsByProductsId('free');
           return rep.status(200).send(freeTier);
         }

--- a/src/controller/products.controller.ts
+++ b/src/controller/products.controller.ts
@@ -8,6 +8,7 @@ import fastifyLimit from '@fastify/rate-limit';
 import { TierNotFoundError, TiersService } from '../services/tiers.service';
 import { User, UserType } from '../core/users/User';
 import { ProductsService } from '../services/products.service';
+import { Tier } from '../core/users/Tier';
 
 export default function (
   tiersService: TiersService,
@@ -69,7 +70,7 @@ export default function (
           };
         };
       };
-    }>('/tier', async (req, rep) => {
+    }>('/tier', async (req, rep): Promise<Tier | Error> => {
       const userUuid = req.user.payload.uuid;
       const ownersId = req.user.payload.workspaces?.owners ?? [];
       const subscriptionType = (req.query.subscriptionType as UserType) || UserType.Individual;

--- a/src/core/users/MongoDBTiersRepository.ts
+++ b/src/core/users/MongoDBTiersRepository.ts
@@ -7,9 +7,11 @@ export interface TiersRepository {
 }
 
 function toDomain(tier: WithId<Omit<Tier, 'id'>>): Tier {
+  const { _id, ...userTier } = tier;
+
   return {
-    ...tier,
-    id: tier._id.toString(),
+    ...userTier,
+    id: _id.toString(),
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import { Bit2MeService } from './services/bit2me.service';
 import { TiersService } from './services/tiers.service';
 import { MongoDBTiersRepository, TiersRepository } from './core/users/MongoDBTiersRepository';
 import { MongoDBUsersTiersRepository, UsersTiersRepository } from './core/users/MongoDBUsersTiersRepository';
+import { ProductsService } from './services/products.service';
 
 const start = async (mongoTestClient?: MongoClient): Promise<FastifyInstance> => {
   const mongoClient = mongoTestClient ?? (await new MongoClient(envVariablesConfig.MONGO_URI).connect());
@@ -71,6 +72,8 @@ const start = async (mongoTestClient?: MongoClient): Promise<FastifyInstance> =>
     envVariablesConfig,
   );
 
+  const productsService = new ProductsService(tiersService, usersService);
+
   const fastify = await buildApp(
     paymentService,
     storageService,
@@ -79,6 +82,7 @@ const start = async (mongoTestClient?: MongoClient): Promise<FastifyInstance> =>
     tiersService,
     licenseCodesService,
     objectStorageService,
+    productsService,
     stripe,
     envVariablesConfig,
   );

--- a/src/services/products.service.ts
+++ b/src/services/products.service.ts
@@ -9,7 +9,7 @@ export class ProductsService {
     private readonly usersService: UsersService,
   ) {}
 
-  async findHigherTierForUser({
+  async getApplicableTierForUser({
     userUuid,
     ownersId,
     subscriptionType,

--- a/src/services/products.service.ts
+++ b/src/services/products.service.ts
@@ -1,4 +1,5 @@
 import { Service, Tier } from '../core/users/Tier';
+import { UserType } from '../core/users/User';
 import { TierNotFoundError, TiersService } from './tiers.service';
 import { UserNotFoundError, UsersService } from './users.service';
 
@@ -8,43 +9,60 @@ export class ProductsService {
     private readonly usersService: UsersService,
   ) {}
 
-  async findHigherTierForUser({ userUuid, ownerId }: { userUuid: string; ownerId?: string[] }): Promise<Tier> {
-    const tiers: Tier[] = [];
-
-    try {
-      const user = await this.usersService.findUserByUuid(userUuid);
-      const userTiers = await this.tiersService.getTiersProductsByUserId(user.id);
-
-      tiers.push(...userTiers);
-    } catch (error) {
-      if (!(error instanceof UserNotFoundError)) throw error;
-    }
-
-    if (ownerId && ownerId?.length > 0) {
-      const ownerTierPromises = ownerId.map(async (ownerUuid) => {
-        try {
-          const owner = await this.usersService.findUserByUuid(ownerUuid);
-          const ownerTiers = await this.tiersService.getTiersProductsByUserId(owner.id);
-
-          return ownerTiers.find((tier) => tier.featuresPerService[Service.Drive].workspaces.enabled) || null;
-        } catch (error) {
-          if (error instanceof UserNotFoundError) return null;
-          throw error;
+  async findHigherTierForUser({
+    userUuid,
+    ownersId,
+    subscriptionType,
+  }: {
+    userUuid: string;
+    ownersId?: string[];
+    subscriptionType: UserType;
+  }): Promise<Tier> {
+    switch (subscriptionType) {
+      case UserType.Individual: {
+        const user = await this.usersService.findUserByUuid(userUuid);
+        const userTiers = await this.tiersService.getTiersProductsByUserId(user.id);
+        if (user.lifetime) {
+          return userTiers.filter((tier) => tier.billingType === 'lifetime')[0];
         }
-      });
 
-      const ownerTiersResolved = await Promise.all(ownerTierPromises);
-      const validOwnerTiers = ownerTiersResolved.filter((tier): tier is Tier => tier !== null);
+        return userTiers.filter((userTier) => !userTier.featuresPerService[Service.Drive].workspaces.enabled)[0];
+      }
 
-      tiers.push(...validOwnerTiers);
+      case UserType.Business: {
+        const tiers: Tier[] = [];
+        if (ownersId && ownersId?.length > 0) {
+          const ownerTierPromises = ownersId.map(async (ownerUuid) => {
+            try {
+              const owner = await this.usersService.findUserByUuid(ownerUuid);
+              const ownerTiers = await this.tiersService.getTiersProductsByUserId(owner.id);
+
+              return ownerTiers.find((tier) => tier.featuresPerService[Service.Drive].workspaces.enabled) || null;
+            } catch (error) {
+              if (error instanceof UserNotFoundError) return null;
+              throw error;
+            }
+          });
+
+          const ownerTiersResolved = await Promise.all(ownerTierPromises);
+          const validOwnerTiers = ownerTiersResolved.filter((tier): tier is Tier => tier !== null);
+
+          tiers.push(...validOwnerTiers);
+        }
+
+        if (tiers.length === 0) {
+          throw new TierNotFoundError(`No tiers found for user uuid ${userUuid} or associated workspaces.`);
+        }
+
+        return [...tiers].sort(
+          (a, b) =>
+            b.featuresPerService[Service.Drive].workspaces.maxSpaceBytesPerSeat -
+            a.featuresPerService[Service.Drive].workspaces.maxSpaceBytesPerSeat,
+        )[0];
+      }
+
+      default:
+        throw new TierNotFoundError(`Tier for ${userUuid} was not found while getting user Tier`);
     }
-
-    if (tiers.length === 0) {
-      throw new TierNotFoundError(`No tiers found for user uuid ${userUuid} or associated workspaces.`);
-    }
-
-    return [...tiers].sort(
-      (a, b) => b.featuresPerService[Service.Drive].maxSpaceBytes - a.featuresPerService[Service.Drive].maxSpaceBytes,
-    )[0];
   }
 }

--- a/src/services/products.service.ts
+++ b/src/services/products.service.ts
@@ -1,0 +1,50 @@
+import { Service, Tier } from '../core/users/Tier';
+import { TierNotFoundError, TiersService } from './tiers.service';
+import { UserNotFoundError, UsersService } from './users.service';
+
+export class ProductsService {
+  constructor(
+    private readonly tiersService: TiersService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async findHigherTierForUser({ userUuid, ownerId }: { userUuid: string; ownerId?: string[] }): Promise<Tier> {
+    const tiers: Tier[] = [];
+
+    try {
+      const user = await this.usersService.findUserByUuid(userUuid);
+      const userTiers = await this.tiersService.getTiersProductsByUserId(user.id);
+
+      tiers.push(...userTiers);
+    } catch (error) {
+      if (!(error instanceof UserNotFoundError)) throw error;
+    }
+
+    if (ownerId && ownerId?.length > 0) {
+      const ownerTierPromises = ownerId.map(async (ownerUuid) => {
+        try {
+          const owner = await this.usersService.findUserByUuid(ownerUuid);
+          const ownerTiers = await this.tiersService.getTiersProductsByUserId(owner.id);
+
+          return ownerTiers.find((tier) => tier.featuresPerService[Service.Drive].workspaces.enabled) || null;
+        } catch (error) {
+          if (error instanceof UserNotFoundError) return null;
+          throw error;
+        }
+      });
+
+      const ownerTiersResolved = await Promise.all(ownerTierPromises);
+      const validOwnerTiers = ownerTiersResolved.filter((tier): tier is Tier => tier !== null);
+
+      tiers.push(...validOwnerTiers);
+    }
+
+    if (tiers.length === 0) {
+      throw new TierNotFoundError(`No tiers found for user uuid ${userUuid} or associated workspaces.`);
+    }
+
+    return [...tiers].sort(
+      (a, b) => b.featuresPerService[Service.Drive].maxSpaceBytes - a.featuresPerService[Service.Drive].maxSpaceBytes,
+    )[0];
+  }
+}

--- a/tests/src/controller/products.controller.test.ts
+++ b/tests/src/controller/products.controller.test.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { closeServerAndDatabase, initializeServerAndDatabase } from '../utils/initializeServer';
-import { getUser, getValidAuthToken } from '../fixtures';
+import { getUser, getValidAuthToken, newTier } from '../fixtures';
 import { UserNotFoundError, UsersService } from '../../../src/services/users.service';
 import { TiersService } from '../../../src/services/tiers.service';
 import { NotFoundSubscriptionError } from '../../../src/services/payment.service';
@@ -97,6 +97,116 @@ describe('Testing products endpoints', () => {
       expect(response.statusCode).toBe(200);
       expect(responseBody).toStrictEqual(mockedAvailableUserProducts);
       expect(getProductsTierSpy).toHaveBeenCalledWith(mockedUser.customerId, mockedUser.lifetime);
+    });
+  });
+
+  describe('Fetching tier for user', () => {
+    it('When an unexpected error occurs, then an error indicating so is thrown', async () => {
+      const mockedUser = getUser();
+      const mockedUserToken = getValidAuthToken(mockedUser.uuid);
+      jest.spyOn(UsersService.prototype, 'findUserByUuid').mockRejectedValue(new Error('Unexpected error'));
+
+      const response = await app.inject({
+        path: `/products/tier`,
+        method: 'GET',
+        headers: { Authorization: `Bearer ${mockedUserToken}` },
+      });
+
+      expect(response.statusCode).toBe(500);
+    });
+
+    describe('When the subscription type is individual', () => {
+      it('When the user is not found, then the free tier is returned successfully', async () => {
+        const mockedUser = getUser();
+        const mockedFreeTier = newTier({
+          id: 'free',
+          label: 'free',
+          productId: 'free',
+        });
+        const mockedUserToken = getValidAuthToken(mockedUser.uuid);
+        jest.spyOn(UsersService.prototype, 'findUserByUuid').mockRejectedValue(new UserNotFoundError('User not found'));
+        jest.spyOn(TiersService.prototype, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
+
+        const response = await app.inject({
+          path: `/products/tier`,
+          method: 'GET',
+          headers: { Authorization: `Bearer ${mockedUserToken}` },
+        });
+
+        const responseBody = response.json();
+
+        expect(response.statusCode).toBe(200);
+        expect(responseBody).toStrictEqual(mockedFreeTier);
+      });
+
+      it('When the user is found and has a valid subscription, then individual tier is returned successfully', async () => {
+        const mockedUser = getUser();
+        const mockedUserToken = getValidAuthToken(mockedUser.uuid);
+        const mockedTier = newTier();
+        jest.spyOn(UsersService.prototype, 'findUserByUuid').mockResolvedValue(mockedUser);
+        jest.spyOn(TiersService.prototype, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
+
+        const response = await app.inject({
+          path: `/products/tier`,
+          method: 'GET',
+          headers: { Authorization: `Bearer ${mockedUserToken}` },
+        });
+
+        const responseBody = response.json();
+
+        expect(response.statusCode).toBe(200);
+        expect(responseBody).toStrictEqual(mockedTier);
+      });
+    });
+
+    describe('When the subscription type is business', () => {
+      it('When the user does not have any associated workspaces, then the free tier is returned successfully', async () => {
+        const mockedUser = getUser();
+        const mockedUserToken = getValidAuthToken(mockedUser.uuid, {
+          owners: [],
+        });
+        const mockedFreeTier = newTier({
+          id: 'free',
+          label: 'free',
+          productId: 'free',
+        });
+
+        jest.spyOn(TiersService.prototype, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
+
+        const response = await app.inject({
+          path: `/products/tier?subscriptionType=business`,
+          method: 'GET',
+          headers: { Authorization: `Bearer ${mockedUserToken}` },
+        });
+
+        const responseBody = response.json();
+
+        expect(response.statusCode).toBe(200);
+        expect(responseBody).toStrictEqual(mockedFreeTier);
+      });
+
+      it('When the user has associated workspaces, then the highest tier is returned successfully', async () => {
+        const mockedUser = getUser();
+        const mockedUserToken = getValidAuthToken(mockedUser.uuid, {
+          owners: [mockedUser.uuid],
+        });
+        const mockedTier = newTier();
+        mockedTier.featuresPerService.drive.workspaces.enabled = true;
+
+        jest.spyOn(UsersService.prototype, 'findUserByUuid').mockResolvedValue(mockedUser);
+        jest.spyOn(TiersService.prototype, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
+
+        const response = await app.inject({
+          path: `/products/tier?subscriptionType=business`,
+          method: 'GET',
+          headers: { Authorization: `Bearer ${mockedUserToken}` },
+        });
+
+        const responseBody = response.json();
+
+        expect(response.statusCode).toBe(200);
+        expect(responseBody).toStrictEqual(mockedTier);
+      });
     });
   });
 });

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -20,8 +20,13 @@ export const getUser = (params?: Partial<User>): User => ({
   ...params,
 });
 
-export const getValidAuthToken = (userUuid: string): string => {
-  return jwt.sign({ payload: { uuid: userUuid } }, config.JWT_SECRET);
+export const getValidAuthToken = (
+  userUuid: string,
+  workspaces?: {
+    owners: string[];
+  },
+): string => {
+  return jwt.sign({ payload: { uuid: userUuid, workspaces } }, config.JWT_SECRET);
 };
 
 export const getValidUserToken = (customerId: string): string => {

--- a/tests/src/services/products.service.test.ts
+++ b/tests/src/services/products.service.test.ts
@@ -9,7 +9,7 @@ import { UsersRepository } from '../../../src/core/users/UsersRepository';
 import { Bit2MeService } from '../../../src/services/bit2me.service';
 import { PaymentService } from '../../../src/services/payment.service';
 import { StorageService } from '../../../src/services/storage.service';
-import { TiersService } from '../../../src/services/tiers.service';
+import { TierNotFoundError, TiersService } from '../../../src/services/tiers.service';
 import { UserNotFoundError, UsersService } from '../../../src/services/users.service';
 import { getUser, newTier } from '../fixtures';
 import testFactory from '../utils/factory';
@@ -79,6 +79,16 @@ describe('Products Service Tests', () => {
   });
 
   describe('Finding the higher tier for a user', () => {
+    it('When the subscription type is not Individual or Business, then an error indicating so is thrown', async () => {
+      const mockedUser = getUser();
+      await expect(
+        productsService.findHigherTierForUser({
+          userUuid: mockedUser.uuid,
+          subscriptionType: UserType.ObjectStorage,
+        }),
+      ).rejects.toThrow(TierNotFoundError);
+    });
+
     describe('When the subscription type is individual', () => {
       it('When the user has a lifetime subscription, then the higher tier is returned', async () => {
         const mockedUser = getUser({

--- a/tests/src/services/products.service.test.ts
+++ b/tests/src/services/products.service.test.ts
@@ -1,0 +1,179 @@
+import Stripe from 'stripe';
+import { CouponsRepository } from '../../../src/core/coupons/CouponsRepository';
+import { UsersCouponsRepository } from '../../../src/core/coupons/UsersCouponsRepository';
+import { DisplayBillingRepository } from '../../../src/core/users/MongoDBDisplayBillingRepository';
+import { TiersRepository } from '../../../src/core/users/MongoDBTiersRepository';
+import { UsersTiersRepository } from '../../../src/core/users/MongoDBUsersTiersRepository';
+import { ProductsRepository } from '../../../src/core/users/ProductsRepository';
+import { UsersRepository } from '../../../src/core/users/UsersRepository';
+import { Bit2MeService } from '../../../src/services/bit2me.service';
+import { PaymentService } from '../../../src/services/payment.service';
+import { StorageService } from '../../../src/services/storage.service';
+import { TiersService } from '../../../src/services/tiers.service';
+import { UserNotFoundError, UsersService } from '../../../src/services/users.service';
+import { getUser, newTier } from '../fixtures';
+import testFactory from '../utils/factory';
+import config from '../../../src/config';
+import axios from 'axios';
+import { ProductsService } from '../../../src/services/products.service';
+import { UserType } from '../../../src/core/users/User';
+import { Service } from '../../../src/core/users/Tier';
+
+let tiersService: TiersService;
+let paymentsService: PaymentService;
+let tiersRepository: TiersRepository;
+let paymentService: PaymentService;
+let usersService: UsersService;
+let usersRepository: UsersRepository;
+let displayBillingRepository: DisplayBillingRepository;
+let couponsRepository: CouponsRepository;
+let usersCouponsRepository: UsersCouponsRepository;
+let usersTiersRepository: UsersTiersRepository;
+let productsRepository: ProductsRepository;
+let bit2MeService: Bit2MeService;
+let storageService: StorageService;
+let productsService: ProductsService;
+
+describe('Products Service Tests', () => {
+  beforeEach(() => {
+    tiersRepository = testFactory.getTiersRepository();
+    usersRepository = testFactory.getUsersRepositoryForTest();
+    paymentsService = new PaymentService(
+      new Stripe(config.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' }),
+      productsRepository,
+      bit2MeService,
+    );
+    usersRepository = testFactory.getUsersRepositoryForTest();
+    displayBillingRepository = {} as DisplayBillingRepository;
+    couponsRepository = testFactory.getCouponsRepositoryForTest();
+    usersCouponsRepository = testFactory.getUsersCouponsRepositoryForTest();
+    usersTiersRepository = testFactory.getUsersTiersRepository();
+    productsRepository = testFactory.getProductsRepositoryForTest();
+    usersTiersRepository = testFactory.getUsersTiersRepository();
+    bit2MeService = new Bit2MeService(config, axios);
+    paymentService = new PaymentService(
+      new Stripe(config.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' }),
+      productsRepository,
+      bit2MeService,
+    );
+    usersService = new UsersService(
+      usersRepository,
+      paymentService,
+      displayBillingRepository,
+      couponsRepository,
+      usersCouponsRepository,
+      config,
+      axios,
+    );
+    storageService = new StorageService(config, axios);
+    tiersService = new TiersService(
+      usersService,
+      paymentService,
+      tiersRepository,
+      usersTiersRepository,
+      storageService,
+      config,
+    );
+
+    productsService = new ProductsService(tiersService, usersService);
+  });
+
+  describe('Finding the higher tier for a user', () => {
+    describe('When the subscription type is individual', () => {
+      it('When the user has a lifetime subscription, then the higher tier is returned', async () => {
+        const mockedUser = getUser({
+          lifetime: true,
+        });
+        const mockedTier = newTier();
+        mockedTier.billingType = 'lifetime';
+
+        jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
+        jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
+
+        const result = await productsService.findHigherTierForUser({
+          userUuid: mockedUser.uuid,
+          subscriptionType: UserType.Individual,
+        });
+
+        expect(result).toStrictEqual(mockedTier);
+        expect(result.billingType).toStrictEqual('lifetime');
+      });
+
+      it('When the user has a subscription, then the higher tier is returned', async () => {
+        const mockedUser = getUser();
+        const mockedTier = newTier();
+        const mockedBusinessTier = newTier();
+        mockedBusinessTier.featuresPerService[Service.Drive].workspaces.enabled = true;
+
+        jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
+        jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier, mockedBusinessTier]);
+
+        const result = await productsService.findHigherTierForUser({
+          userUuid: mockedUser.uuid,
+          subscriptionType: UserType.Individual,
+        });
+
+        expect(result).toStrictEqual(mockedTier);
+        expect(result.billingType).toStrictEqual('subscription');
+      });
+    });
+
+    describe('When the subscription type is business', () => {
+      it('When the user has only one owner Id, then the this subscription tier is returned', async () => {
+        const mockedUser = getUser();
+        const mockedTier = newTier();
+        const mockedBusinessTier = newTier();
+        mockedBusinessTier.featuresPerService[Service.Drive].workspaces.enabled = true;
+
+        jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
+        jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier, mockedBusinessTier]);
+
+        const result = await productsService.findHigherTierForUser({
+          userUuid: mockedUser.uuid,
+          ownersId: [mockedUser.uuid],
+          subscriptionType: UserType.Business,
+        });
+
+        expect(result).toStrictEqual(mockedBusinessTier);
+        expect(result.billingType).toStrictEqual('subscription');
+      });
+
+      it('When the user has multiple owner Ids, then the highest tier is returned', async () => {
+        const mockedUser = getUser();
+        const mockedOwner = getUser();
+        const mockedTier = newTier();
+        const mockedBusinessTier = newTier();
+        const mockedBusinessTier2 = newTier();
+
+        mockedBusinessTier.featuresPerService[Service.Drive].workspaces.enabled = true;
+        mockedBusinessTier.featuresPerService[Service.Drive].workspaces.maxSpaceBytesPerSeat = 1000000;
+        mockedBusinessTier2.featuresPerService[Service.Drive].workspaces.enabled = true;
+        mockedBusinessTier2.featuresPerService[Service.Drive].workspaces.maxSpaceBytesPerSeat = 2000000;
+
+        jest.spyOn(usersService, 'findUserByUuid').mockImplementation(async (uuid: string) => {
+          if (uuid === mockedUser.uuid) return mockedUser;
+          if (uuid === mockedOwner.uuid) return mockedOwner;
+          throw new UserNotFoundError(`User with uuid ${uuid} not found`);
+        });
+        jest.spyOn(tiersService, 'getTiersProductsByUserId').mockImplementation(async (ownerId: string) => {
+          if (ownerId === mockedUser.id) {
+            return [mockedTier, mockedBusinessTier];
+          }
+          if (ownerId === mockedOwner.id) {
+            return [mockedTier, mockedBusinessTier2];
+          }
+          return [];
+        });
+
+        const result = await productsService.findHigherTierForUser({
+          userUuid: mockedUser.uuid,
+          ownersId: [mockedUser.uuid, mockedOwner.uuid],
+          subscriptionType: UserType.Business,
+        });
+
+        expect(result).toStrictEqual(mockedBusinessTier2);
+        expect(result.billingType).toStrictEqual('subscription');
+      });
+    });
+  });
+});

--- a/tests/src/services/products.service.test.ts
+++ b/tests/src/services/products.service.test.ts
@@ -82,7 +82,7 @@ describe('Products Service Tests', () => {
     it('When the subscription type is not Individual or Business, then an error indicating so is thrown', async () => {
       const mockedUser = getUser();
       await expect(
-        productsService.findHigherTierForUser({
+        productsService.getApplicableTierForUser({
           userUuid: mockedUser.uuid,
           subscriptionType: UserType.ObjectStorage,
         }),
@@ -100,7 +100,7 @@ describe('Products Service Tests', () => {
         jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
         jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier]);
 
-        const result = await productsService.findHigherTierForUser({
+        const result = await productsService.getApplicableTierForUser({
           userUuid: mockedUser.uuid,
           subscriptionType: UserType.Individual,
         });
@@ -118,7 +118,7 @@ describe('Products Service Tests', () => {
         jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
         jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier, mockedBusinessTier]);
 
-        const result = await productsService.findHigherTierForUser({
+        const result = await productsService.getApplicableTierForUser({
           userUuid: mockedUser.uuid,
           subscriptionType: UserType.Individual,
         });
@@ -138,7 +138,7 @@ describe('Products Service Tests', () => {
         jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
         jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedTier, mockedBusinessTier]);
 
-        const result = await productsService.findHigherTierForUser({
+        const result = await productsService.getApplicableTierForUser({
           userUuid: mockedUser.uuid,
           ownersId: [mockedUser.uuid],
           subscriptionType: UserType.Business,
@@ -175,7 +175,7 @@ describe('Products Service Tests', () => {
           return [];
         });
 
-        const result = await productsService.findHigherTierForUser({
+        const result = await productsService.getApplicableTierForUser({
           userUuid: mockedUser.uuid,
           ownersId: [mockedUser.uuid, mockedOwner.uuid],
           subscriptionType: UserType.Business,


### PR DESCRIPTION
This PR implements a new endpoint to get the user's tier if he has one, depending on whether the individual tier or the business tier is requested.
- If the individual tier is requested, it is searched by the tier associated to the user. 
- If the business tier is requested, we search if the user has any active business subscription and if he belongs to a Workspace (as if he“belongs” to the active subscription of the owner of another workspace). We obtain the all tiers related to the workspaces he pertain, filter by the highest one and return it.