### PR TITLE
[_]: feat/subscription-with-trial-for-pccomponentes

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -32,6 +32,7 @@ jobs:
       - run: echo CRYPTO_PAYMENTS_PROCESSOR_API_URL=url >> ./.env
       - run: echo DRIVE_NEW_GATEWAY_SECRET=secret >> ./.env
       - run: echo PC_CLOUD_TRIAL_CODE=my_code >> ./.env
+       run: echo PC_COMPONENTES_TRIAL_CODE=my_code >> ./.env
 
       - run: echo "registry=https://registry.yarnpkg.com/" > .npmrc
       - run: echo "@internxt:registry=https://npm.pkg.github.com" >> .npmrc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,7 @@ jobs:
       - run: echo CRYPTO_PAYMENTS_PROCESSOR_API_URL=url >> ./.env
       - run: echo DRIVE_NEW_GATEWAY_SECRET=secret >> ./.env
       - run: echo PC_CLOUD_TRIAL_CODE=my_code >> ./.env
+      - run: echo PC_COMPONENTES_TRIAL_CODE=my_code >> ./.env
 
       - run: echo "registry=https://registry.yarnpkg.com/" > .npmrc
       - run: echo "@internxt:registry=https://npm.pkg.github.com" >> .npmrc

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ const mandatoryVariables = [
   'CRYPTO_PAYMENTS_PROCESSOR_API_KEY',
   'VPN_URL',
   'PC_CLOUD_TRIAL_CODE',
+  'PC_COMPONENTES_TRIAL_CODE'
 ] as const;
 
 type BaseConfig = {

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -522,7 +522,7 @@ export default function (
 
         try {
           const payload = jwt.verify(trialToken, config.JWT_SECRET) as { trial?: string };
-          if (!payload.trial || payload.trial !== 'pc-cloud-25') {
+          if (!payload.trial ||( payload.trial !== 'pc-cloud-25' && payload.trial !== 'pc-componenes-25')) {
             throw new Error('Invalid trial token');
           }
         } catch {
@@ -537,7 +537,7 @@ export default function (
               currency,
             },
             {
-              name: 'pc-cloud-25',
+              name: trialToken,
             },
           );
 
@@ -571,11 +571,16 @@ export default function (
       Querystring: { code: string };
     }>('/trial-for-subscription', async (req, rep) => {
       const { code } = req.query;
-      if (!code || code !== process.env.PC_CLOUD_TRIAL_CODE) {
-        return rep.status(400).send();
+      if (!code || (code !== process.env.PC_CLOUD_TRIAL_CODE && code !== process.env.PC_COMPONENTES_TRIAL_CODE)) {
+        return rep.status(400).send({ message: 'Invalid trial code' });
       }
 
-      return jwt.sign({ trial: 'pc-cloud-25' }, config.JWT_SECRET);
+      if (code === process.env.PC_CLOUD_TRIAL_CODE) {
+        return jwt.sign({ trial: 'pc-cloud-25' }, config.JWT_SECRET);
+      }else{
+        return jwt.sign({ trial: 'pc-componentes-25' }, config.JWT_SECRET);
+      }
+
     });
 
     fastify.get('/users/exists', async (req, rep) => {

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -538,7 +538,7 @@ export default function (
               currency,
             },
             {
-            name: metadata.name as 'pc-cloud-25' | 'pc-componentes-25' | 'prevent-cancellation',
+            name: 'pc-cloud-25' ,
             },
           );
           

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -520,17 +520,16 @@ export default function (
           return res.status(403).send('Invalid trial token');
         }
 
-        const validTrials = ['pc-cloud-25', 'pc-componentes-25'];
-
         try {
           const payload = jwt.verify(trialToken, config.JWT_SECRET) as { trial?: string };
-          if (!payload.trial || !validTrials.includes(payload.trial)) {
+          if (!payload.trial || !['pc-cloud-25', 'pc-componentes-25'].includes(payload.trial)) {
             throw new Error('Invalid trial token');
           }
-          const metadata = {
-            name: payload.trial,
-            trialToken: trialToken,
-          };
+        } catch {
+          return res.status(403).send('Invalid trial token');
+        }
+
+        try {
           const subscriptionSetup = await paymentService.createSubscriptionWithTrial(
             {
               customerId,
@@ -538,11 +537,10 @@ export default function (
               currency,
             },
             {
-            name: 'pc-cloud-25' ,
+              name: 'pc-cloud-25',
             },
           );
-          
-      
+
           return res.send(subscriptionSetup);
         } catch (err) {
           const error = err as Error;

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -527,11 +527,10 @@ export default function (
           if (!payload.trial || !validTrials.includes(payload.trial)) {
             throw new Error('Invalid trial token');
           }
-        } catch {
-          return res.status(403).send('Invalid trial token');
-        }
-
-        try {
+          const metadata = {
+            name: payload.trial,
+            trialToken: trialToken,
+          };
           const subscriptionSetup = await paymentService.createSubscriptionWithTrial(
             {
               customerId,
@@ -539,10 +538,11 @@ export default function (
               currency,
             },
             {
-              name: trialToken,
+            name: metadata.name as 'pc-cloud-25' | 'pc-componentes-25' | 'prevent-cancellation',
             },
           );
-
+          
+      
           return res.send(subscriptionSetup);
         } catch (err) {
           const error = err as Error;

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -19,7 +19,6 @@ import {
   UserAlreadyExistsError,
   CustomerNotFoundError,
   InvalidTaxIdError,
-  Reason,
 } from '../services/payment.service';
 import { User, UserSubscription, UserType } from '../core/users/User';
 import CacheService from '../services/cache.service';
@@ -520,14 +519,14 @@ export default function (
         if (!trialToken) {
           return res.status(403).send('Invalid trial token');
         }
-        const validTrialValues: Reason['name'][] = ['prevent-cancellation', 'pc-cloud-25', 'pc-componentes-25'];
-       
+
+        const validTrials = ['pc-cloud-25', 'pc-componentes-25'];
+
         try {
           const payload = jwt.verify(trialToken, config.JWT_SECRET) as { trial?: string };
-          if (!payload.trial || !validTrialValues.includes(payload.trial as Reason['name'])) {
+          if (!payload.trial || !validTrials.includes(payload.trial)) {
             throw new Error('Invalid trial token');
           }
-          
         } catch {
           return res.status(403).send('Invalid trial token');
         }

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -67,7 +67,7 @@ export interface PaymentIntent {
 }
 
 export type Reason = {
-  name: 'prevent-cancellation' | 'pc-cloud-25';
+  name: 'prevent-cancellation' | 'pc-cloud-25' |'pc-componentes-25';
 };
 
 const commonPaymentMethodTypes: Record<string, Stripe.Checkout.SessionCreateParams.PaymentMethodType[]> = {
@@ -83,6 +83,7 @@ const additionalPaymentTypesForOneTime: Record<string, Stripe.Checkout.SessionCr
 const reasonFreeMonthsMap: Record<Reason['name'], number> = {
   'prevent-cancellation': 3,
   'pc-cloud-25': 6,
+  'pc-componentes-25': 6,
 };
 
 export type PriceMetadata = {

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -400,5 +400,33 @@ describe('Payments Service tests', () => {
         metadata: { 'why-trial': trialReason.name },
       });
     });
+    
+    it('When creating a subscription with trial for pc-componentes-25, then it creates the sub with the correct trial end date', async () => {
+      const fixedDate = new Date('2024-01-01T12:00:00Z');
+      jest.setSystemTime(fixedDate);
+    
+      const expected = getCreateSubscriptionResponse();
+      const payload = {
+        customerId: getCustomer().id,
+        priceId: getPrices().subscription.exists,
+      };
+      const trialReason: Reason = { name: 'pc-componentes-25' };
+    
+      const trialMonths = 6;
+      const expectedTrialEnd = Math.floor(
+        new Date(fixedDate.setMonth(fixedDate.getMonth() + trialMonths)).getTime() / 1000
+      );
+    
+      const createSubSpy = jest.spyOn(paymentService, 'createSubscription').mockResolvedValue(expected);
+    
+      const received = await paymentService.createSubscriptionWithTrial(payload, trialReason);
+    
+      expect(received).toStrictEqual(expected);  
+      expect(createSubSpy).toHaveBeenCalledWith({
+        ...payload,
+        trialEnd: expectedTrialEnd,
+        metadata: { 'why-trial': trialReason.name },
+      });
+    });
   });  
 });


### PR DESCRIPTION
This PR introduces several improvements related to the subscription system, focusing on the integration of a new trial type, pc-components-25. The changes include:

1. Update in config.ts:

- The environment variable PC_COMPONENTES_TRIAL_CODE has been added to the list of mandatory variables for use in workflows.

2. Modifications in payments.controller.ts:

- The trial token validation has been extended to allow the pc-cloud-25 and pc-components-25 trial types.

- Subscription creation has been updated to accept these new trial types during the registration process.

3. Update in payment.service.ts:

- pc-components-25 has been added as a valid trial type within the subscription logic and the maps related to free trial periods.

4. New tests in payment.service.test.ts:

- A new test case has been added to validate subscription creation with the pc-components-25 trial option, ensuring the correct calculation of the trial end date