### PR TITLE
[_]: hotfix/get correct customer before payment

### DIFF
--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -31,6 +31,7 @@ import { Coupon } from '../core/coupons/Coupon';
 import { assertUser } from '../utils/assertUser';
 import { fetchUserStorage } from '../utils/fetchUserStorage';
 import { TierNotFoundError, TiersService } from '../services/tiers.service';
+import { CustomerSyncService } from '../services/customerSync.service';
 
 type AllowedMethods = 'GET' | 'POST';
 
@@ -173,6 +174,7 @@ export default function (
       },
       async (req, res) => {
         const { name, email, country, companyVatId } = req.body;
+        const { uuid } = req.user.payload;
 
         if (!email) {
           return res.status(404).send({
@@ -181,26 +183,31 @@ export default function (
         }
 
         try {
-          const { id } = await paymentService.createOrGetCustomer(
-            {
-              name,
-              email,
-            },
-            country,
-            companyVatId,
-          );
+          if (uuid) {
+            const user = await usersService.findUserByUuid(uuid);
+            return user.customerId;
+          }
+        } catch (error) {
+          req.log.info(`User with uuid ${uuid} does not exists in our Local DB`);
+        }
 
-          const token = jwt.sign(
-            {
-              customerId: id,
-            },
-            config.JWT_SECRET,
-          );
+        try {
+          const customerSyncService = new CustomerSyncService(usersService, paymentService);
 
-          return res.send({
-            customerId: id,
-            token,
-          });
+          const existingCustomerId = await customerSyncService.findOrSyncCustomerByUuidOrEmail(uuid, email);
+
+          if (existingCustomerId) {
+            const token = jwt.sign({ customerId: existingCustomerId }, config.JWT_SECRET);
+            return res.send({ customerId: existingCustomerId, token });
+          }
+
+          const { id } = await paymentService.createCustomer({ name, email });
+
+          await paymentService.getVatIdAndAttachTaxIdToCustomer(id, country, companyVatId);
+
+          const token = jwt.sign({ customerId: id }, config.JWT_SECRET);
+
+          return res.send({ customerId: id, token });
         } catch (err) {
           const error = err as Error;
 

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -183,15 +183,6 @@ export default function (
         }
 
         try {
-          if (uuid) {
-            const user = await usersService.findUserByUuid(uuid);
-            return user.customerId;
-          }
-        } catch (error) {
-          req.log.info(`User with uuid ${uuid} does not exists in our Local DB`);
-        }
-
-        try {
           const customerSyncService = new CustomerSyncService(usersService, paymentService);
 
           const existingCustomerId = await customerSyncService.findOrSyncCustomerByUuidOrEmail(uuid, email);

--- a/src/services/customerSync.service.ts
+++ b/src/services/customerSync.service.ts
@@ -1,0 +1,55 @@
+import { UsersService } from './users.service';
+import { PaymentService } from './payment.service';
+import { User } from '../core/users/User';
+
+export class CustomerSyncService {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly paymentService: PaymentService,
+  ) {}
+
+  async findOrSyncCustomerByUuidOrEmail(uuid: string, email: string): Promise<string | null> {
+    let user: User | null = null;
+
+    try {
+      user = await this.usersService.findUserByUuid(uuid);
+      if (user.customerId) return user.customerId;
+    } catch {
+      // No action, we'll try with email
+    }
+
+    const stripeCustomers = await this.paymentService.getCustomersByEmail(email);
+
+    if (stripeCustomers.length === 0) {
+      return null;
+    }
+
+    if (stripeCustomers.length === 1) {
+      const [customer] = stripeCustomers;
+      const existingUser = await this.usersService.findUserByCustomerID(customer.id);
+
+      if (!existingUser) return customer.id;
+
+      // Si el uuid ha cambiado, actualizamos
+      if (existingUser.uuid !== uuid) {
+        await this.usersService.updateUser(customer.id, {
+          uuid,
+        });
+      }
+
+      return customer.id;
+    }
+
+    const matchedCustomer = stripeCustomers.find(async (customer) => {
+      const customerId = customer.id;
+      const matched = await this.usersService.findUserByCustomerID(customerId);
+      return matched?.uuid === uuid;
+    });
+
+    if (matchedCustomer) {
+      return matchedCustomer.id;
+    }
+
+    return null;
+  }
+}

--- a/src/services/customerSync.service.ts
+++ b/src/services/customerSync.service.ts
@@ -1,6 +1,7 @@
 import { UsersService } from './users.service';
 import { PaymentService } from './payment.service';
 import { User } from '../core/users/User';
+import Stripe from 'stripe';
 
 export class CustomerSyncService {
   constructor(
@@ -39,11 +40,15 @@ export class CustomerSyncService {
       return customer.id;
     }
 
-    const matchedCustomer = stripeCustomers.find(async (customer) => {
-      const customerId = customer.id;
-      const matched = await this.usersService.findUserByCustomerID(customerId);
-      return matched?.uuid === uuid;
-    });
+    let matchedCustomer: Stripe.Customer | undefined;
+
+    for (const customer of stripeCustomers) {
+      const matched = await this.usersService.findUserByCustomerID(customer.id);
+      if (matched?.uuid === uuid) {
+        matchedCustomer = customer;
+        break;
+      }
+    }
 
     if (matchedCustomer) {
       return matchedCustomer.id;

--- a/src/services/customerSync.service.ts
+++ b/src/services/customerSync.service.ts
@@ -30,7 +30,6 @@ export class CustomerSyncService {
 
       if (!existingUser) return customer.id;
 
-      // Si el uuid ha cambiado, actualizamos
       if (existingUser.uuid !== uuid) {
         await this.usersService.updateUser(customer.id, {
           uuid,

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -139,7 +139,7 @@ export class PaymentService {
     return customer;
   }
 
-  private async getVatIdAndAttachTaxIdToCustomer(customerId: CustomerId, country?: string, companyVatId?: string) {
+  async getVatIdAndAttachTaxIdToCustomer(customerId: CustomerId, country?: string, companyVatId?: string) {
     try {
       if (country && companyVatId) {
         const taxIds = this.getVatIdFromCountry(country);

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -38,7 +38,7 @@ export class UsersService {
     private readonly axios: Axios,
   ) {}
 
-  async updateUser(customerId: User['customerId'], body: Pick<User, 'lifetime'>): Promise<void> {
+  async updateUser(customerId: User['customerId'], body: Partial<User>): Promise<void> {
     const updated = await this.usersRepository.updateUser(customerId, body);
     if (!updated) {
       throw new UserNotFoundError();


### PR DESCRIPTION
This RP gets the correct customer when trying to get the customer ID to make a payment. For this case, what we do is the following:
- We check that it exists in the local database using the uuid. If it exists, we return the existing one.
- If it does not exist by uuid, we obtain the customerIds associated to the user's email in Stripe.
- If it has any customerId, we check if any of them match with the one we have in the local database. If it is the case, we check if the uuid matches. If they do not match, then we update the uuid of that item in the collection and return the existing customer Id. 

If none of the above steps is successful, then we create a customer id.