### PR TITLE
[PB-4287]: feat/redis invoice lock

### DIFF
--- a/src/webhooks/handleInvoiceCompleted.ts
+++ b/src/webhooks/handleInvoiceCompleted.ts
@@ -74,7 +74,7 @@ export default async function handleInvoiceCompleted(
 
   if (customer.deleted) {
     log.error(
-      `Customer ${session.customer} could not be retrieved in invoice.payment_succeeded event for invoice ${session.id}`,
+      `Customer ${session.customer as string} could not be retrieved in invoice.payment_succeeded event for invoice ${session.id}`,
     );
     return;
   }

--- a/src/webhooks/invoices/paymentSucceeded/handler.ts
+++ b/src/webhooks/invoices/paymentSucceeded/handler.ts
@@ -147,10 +147,12 @@ export async function handleInvoiceCompleted({
       if (userHasLifetime) {
         const lifetimeTier = await tiersService.getTierProductsByProductsId(product.id, 'lifetime');
 
-        userStackedStorage = await getStackedSpace(
+        const stackedUserSpace = await getStackedSpace(
           { uuid: user.uuid, email: customerEmail },
           lifetimeTier.featuresPerService[Service.Drive].maxSpaceBytes,
         );
+
+        userStackedStorage = await cacheService.setFirstStackValue(session.id, stackedUserSpace);
 
         logger.info(
           `[${session.id}] [LIFETIME/STACK] User ${user.uuid} will stack storage up to ${userStackedStorage} bytes`,
@@ -161,15 +163,6 @@ export async function handleInvoiceCompleted({
     }
   }
 
-  try {
-    const isFirstTrigger = await cacheService.getInvoiceLock(session.id);
-    if (!isFirstTrigger) return;
-  } catch (error) {
-    const err = error as Error;
-    logger.error(
-      `[${session.id}] Error checking if the event has been triggered previously. ERROR: ${err.stack ?? err.message}`,
-    );
-  }
   // 9a. Apply tier
   try {
     const tier = await tiersService.getTierProductsByProductsId(product.id, billingType);
@@ -200,8 +193,6 @@ export async function handleInvoiceCompleted({
       userUuid: user.uuid,
     });
   }
-
-  await cacheService.setInvoiceLock(session.id);
 
   // 9b. Insert - update user
   await upsertUser({
@@ -240,7 +231,6 @@ export async function handleInvoiceCompleted({
   // 11. Clear subscription cache
   try {
     await cacheService.clearSubscription(customer.id);
-    await cacheService.clearInvoiceLock(session.id);
     logger.info(
       `[${session.id}] Cache for user with uuid: ${user.uuid} and customer Id: ${customer.id} has been cleaned`,
     );


### PR DESCRIPTION
This PR implements a new caching system for lifetime stacked storage. 

Since it is a critical path if the webhook fails since the storage is added every time the event is automatically re-executed by Stripe, we have to prevent overstacked space earlier. 

Thus, we save the first stacked storage value in Redis and use it if needed when the event fails.