### PR TITLE
[PB-4338]: fix(customer-creation)/customer creation

### DIFF
--- a/src/services/customerSync.service.ts
+++ b/src/services/customerSync.service.ts
@@ -27,7 +27,8 @@ export class CustomerSyncService {
 
     if (stripeCustomers.length === 1) {
       const [customer] = stripeCustomers;
-      const existingUser = await this.usersService.findUserByCustomerID(customer.id);
+      // This throws, we need to catch it
+      const existingUser = await this.usersService.findUserByCustomerID(customer.id).catch(() => null);
 
       if (!existingUser) return customer.id;
 


### PR DESCRIPTION
If customer does not exist in payments DB but it exists in Stripe, catch the error thrown by the function findUserByCustomerID