### PR TITLE
[_]: feat/create payment intent

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -207,7 +207,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
           promoCodeId,
         );
 
-        return { clientSecret, id, invoiceStatus };
+        return res.status(200).send({ clientSecret, id, invoiceStatus });
       },
     );
   };

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -342,6 +342,88 @@ export class PaymentService {
     }
   }
 
+  /**
+   * Creates an invoice to purchase a one time plan.
+   *
+   * @param customerId - The ID of the customer who is purchasing the plan.
+   * @param priceId - The ID of the price associated with the lifetime plan.
+   * @param currency - The currency in which the purchase is made.
+   * @param promoCodeId - (Optional) The promotion code applied to the purchase, if any.
+   *
+   * @returns {PaymentIntent} An object containing:
+   * - `client_secret`: to be used with Stripe Elements,
+   * - `invoice_id`: the ID of the created invoice,
+   * - `invoice_status`: the current status of the invoice (e.g., `paid`, `open`, etc.).
+   */
+  async createInvoice(
+    customerId: string,
+    priceId: string,
+    currency = 'eur',
+    promoCodeId?: string,
+  ): Promise<PaymentIntent> {
+    let couponId: string | undefined = undefined;
+
+    const invoice = await this.provider.invoices.create({
+      customer: customerId,
+      currency: currency,
+      payment_settings: {
+        payment_method_types: ['card', 'paypal'],
+      },
+    });
+
+    if (promoCodeId) {
+      couponId = await this.checkIfCouponIsAplicable(customerId, promoCodeId);
+    }
+
+    await this.provider.invoiceItems.create({
+      customer: customerId,
+      price: priceId,
+      invoice: invoice.id,
+      discounts: [
+        {
+          coupon: couponId,
+        },
+      ],
+    });
+
+    const finalizedInvoice = await this.provider.invoices.finalizeInvoice(invoice.id);
+
+    const paymentIntentForFinalizedInvoice = finalizedInvoice.payment_intent;
+
+    if (!paymentIntentForFinalizedInvoice && finalizedInvoice.status === 'paid') {
+      return {
+        clientSecret: '',
+        id: '',
+        invoiceStatus: finalizedInvoice.status,
+      };
+    }
+
+    const { client_secret, id } = await this.provider.paymentIntents.retrieve(
+      paymentIntentForFinalizedInvoice as string,
+    );
+
+    return {
+      clientSecret: client_secret,
+      id,
+    };
+  }
+
+  /**
+   * @deprecated Use `createInvoice` instead.
+   *
+   * Creates an invoice to purchase a lifetime plan.
+   *
+   * @param customerId - The ID of the customer who is purchasing the plan.
+   * @param priceId - The ID of the price associated with the lifetime plan.
+   * @param currency - The currency in which the purchase is made.
+   * @param promoCodeId - (Optional) The promotion code applied to the purchase, if any.
+   *
+   * @returns {PaymentIntent} An object containing:
+   * - `client_secret`: to be used with Stripe Elements,
+   * - `invoice_id`: the ID of the created invoice,
+   * - `invoice_status`: the current status of the invoice (e.g., `paid`, `open`, etc.).
+   */
+
   async createPaymentIntent(
     customerId: CustomerId,
     amount: number,

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -182,7 +182,7 @@ export class PaymentService {
     return newCustomer;
   }
 
-  private async checkIfCouponIsAplicable(customerId: CustomerId, promoCodeId: Stripe.PromotionCode['id']) {
+  public async checkIfCouponIsAplicable(customerId: CustomerId, promoCodeId: Stripe.PromotionCode['id']) {
     const userInvoices = await this.getInvoicesFromUser(customerId, {});
     const hasUserExistingInvoices = userInvoices.length > 0;
     const hasUserPaidInvoices = userInvoices.some((invoice) => invoice.status === 'paid');
@@ -377,8 +377,8 @@ export class PaymentService {
 
     await this.provider.invoiceItems.create({
       customer: customerId,
-      price: priceId,
       invoice: invoice.id,
+      price: priceId,
       discounts: [
         {
           coupon: couponId,

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -116,6 +116,33 @@ export const getPrices = () => {
   };
 };
 
+export const priceById = ({
+  bytes,
+  interval,
+  type = UserType.Individual,
+  businessSeats,
+}: {
+  bytes: number;
+  interval: 'lifetime' | 'year';
+  type?: UserType;
+  businessSeats?: {
+    maxSeats: number;
+    minSeats: number;
+  };
+}) => {
+  const mockedPrice = getPrice();
+  return {
+    id: mockedPrice.id,
+    currency: mockedPrice.currency,
+    amount: mockedPrice.currency_options![mockedPrice.currency].unit_amount as number,
+    bytes,
+    interval,
+    decimalAmount: (mockedPrice.currency_options![mockedPrice.currency].unit_amount as number) / 100,
+    type,
+    ...businessSeats,
+  };
+};
+
 export const getPrice = (params?: Partial<Stripe.Price>): Stripe.Price => {
   return {
     id: `price_${randomDataGenerator.string({ length: 12 })}`,


### PR DESCRIPTION
This PR introduces a new endpoint to create a Stripe Payment Intent, allowing users to purchase one-time products such as lifetime plans.

The endpoint is exposed via `POST /checkout/payment-intent`, and includes full test coverage to ensure correct behavior.