### PR TITLE
[_]: feat/get price by id

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -1,0 +1,7 @@
+import 'fastify';
+
+declare module 'fastify' {
+  interface FastifyContextConfig {
+    skipAuth?: boolean;
+  }
+}

--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -224,6 +224,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
         schema: {
           querystring: {
             type: 'object',
+            required: ['priceId'],
             properties: {
               priceId: { type: 'string', description: 'Price ID to fetch' },
               currency: { type: 'string', description: 'Optional currency for the price', default: 'eur' },

--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -23,6 +23,11 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
     });
 
     fastify.addHook('onRequest', async (request) => {
+      const skipAuth = request.routeOptions?.config?.skipAuth;
+
+      if (skipAuth) {
+        return;
+      }
       try {
         await request.jwtVerify();
       } catch (err) {
@@ -208,6 +213,42 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
         );
 
         return { clientSecret, id, invoiceStatus };
+      },
+    );
+
+    fastify.get<{
+      Querystring: { priceId: string; currency?: string };
+    }>(
+      '/price-by-id',
+      {
+        schema: {
+          querystring: {
+            type: 'object',
+            properties: {
+              priceId: { type: 'string', description: 'Price ID to fetch' },
+              currency: { type: 'string', description: 'Optional currency for the price', default: 'eur' },
+            },
+          },
+        },
+        config: {
+          skipAuth: true,
+        },
+      },
+      async (req, res) => {
+        const { priceId, currency } = req.query;
+        const userIp = req.headers['x-real-ip'] as string;
+
+        const price = await paymentsService.getPriceById(priceId, currency);
+
+        const taxForPrice = await paymentsService.getTaxForPrice(priceId, price.amount, userIp, currency);
+
+        return res.status(200).send({
+          ...price,
+          tax: taxForPrice.tax_amount_exclusive,
+          decimalTax: taxForPrice.tax_amount_exclusive / 100,
+          amountWithTax: taxForPrice.amount_total,
+          decimalAmountWithTax: taxForPrice.amount_total / 100,
+        });
       },
     );
   };

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1156,6 +1156,30 @@ export class PaymentService {
     };
   }
 
+  async getTaxForPrice(
+    priceId: string,
+    amount: number,
+    ipAddress: string,
+    currency = 'eur',
+  ): Promise<Stripe.Tax.Calculation> {
+    const tax = await this.provider.tax.calculations.create({
+      customer_details: {
+        ip_address: ipAddress,
+      },
+      line_items: [
+        {
+          amount,
+          reference: priceId,
+          tax_behavior: 'exclusive',
+          quantity: 1,
+        },
+      ],
+      currency,
+    });
+
+    return tax;
+  }
+
   /**
    * Deprecated - Use getPriceById instead
    * @param priceId - Id of the price we want to fetch

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1156,6 +1156,14 @@ export class PaymentService {
     };
   }
 
+  /**
+   * Returns the tax for a given price
+   * @param priceId - The Id of the price that we want to calculate the tax for
+   * @param amount - The amount of the price
+   * @param ipAddress - The IP address of the user
+   * @param currency - The currency of the price
+   * @returns - The tax calculation object
+   */
   async getTaxForPrice(
     priceId: string,
     amount: number,

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -116,6 +116,44 @@ export const getPrices = () => {
   };
 };
 
+export const getTaxes = (): Stripe.Tax.Calculation => {
+  return {
+    id: 'taxcalc_1RMT1aFAOdcgaBMQEoAm2Pee',
+    object: 'tax.calculation',
+    amount_total: 14505,
+    currency: 'eur',
+    customer: null,
+    customer_details: {
+      address: null,
+      address_source: null,
+      ip_address: '93.176.146.32',
+      tax_ids: [],
+      taxability_override: 'none',
+    },
+    expires_at: 1754481242,
+    livemode: false,
+    ship_from_details: null,
+    shipping_cost: null,
+    tax_amount_exclusive: 2517,
+    tax_amount_inclusive: 0,
+    tax_breakdown: [
+      {
+        amount: 2517,
+        inclusive: false,
+        tax_rate_details: {
+          country: 'ES',
+          percentage_decimal: '21',
+          state: 'ES',
+          tax_type: 'vat',
+        },
+        taxability_reason: 'standard_rated',
+        taxable_amount: 11988,
+      },
+    ],
+    tax_date: 1746705242,
+  };
+};
+
 export const priceById = ({
   bytes,
   interval,

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -536,7 +536,9 @@ describe('Payments Service tests', () => {
     it('When the params are correct, then a tax object is returned for the requested price', async () => {
       const mockedPrice = getPrice();
       const mockedTaxes = getTaxes();
-      jest.spyOn(paymentService, 'getTaxForPrice').mockResolvedValue(mockedTaxes);
+      jest
+        .spyOn(stripe.tax.calculations, 'create')
+        .mockResolvedValue(mockedTaxes as Stripe.Response<Stripe.Tax.Calculation>);
 
       const taxes = await paymentService.getTaxForPrice(mockedPrice.id, mockedPrice.unit_amount as number, 'user_ip');
 

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -19,6 +19,7 @@ import {
   getPrice,
   getPrices,
   getPromotionCode,
+  getTaxes,
   getUser,
 } from '../fixtures';
 import { NotFoundError } from '../../../src/errors/Errors';
@@ -528,6 +529,18 @@ describe('Payments Service tests', () => {
       const price = await paymentService.getPriceById(validPriceId);
 
       expect(price).toStrictEqual(priceResponse);
+    });
+  });
+
+  describe('Get tax for a price', () => {
+    it('When the params are correct, then a tax object is returned for the requested price', async () => {
+      const mockedPrice = getPrice();
+      const mockedTaxes = getTaxes();
+      jest.spyOn(paymentService, 'getTaxForPrice').mockResolvedValue(mockedTaxes);
+
+      const taxes = await paymentService.getTaxForPrice(mockedPrice.id, mockedPrice.unit_amount as number, 'user_ip');
+
+      expect(taxes).toStrictEqual(mockedTaxes);
     });
   });
 });


### PR DESCRIPTION
This PR introduces a new endpoint to retrieve a product price by its ID, including tax calculations.

The endpoint is GET /checkout/price-by-id.
It returns:
* The base price (without taxes),
* The calculated tax amount (based on the user's location),
* The total amount (price + taxes).

This allows the frontend to display a detailed price breakdown to the user before completing the purchase.