### PR TITLE
[_]: feat/calculate taxes using discounts

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -3,5 +3,6 @@ import 'fastify';
 declare module 'fastify' {
   interface FastifyContextConfig {
     skipAuth?: boolean;
+    allowAnonymous?: boolean;
   }
 }

--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -266,7 +266,6 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
 
         if (promoCodeName) {
           const couponCode = await paymentsService.getPromoCodeByName(price.product, promoCodeName);
-          console.log('Coupon code:', couponCode);
           if (couponCode.amountOff) {
             amount = price.amount - couponCode.amountOff;
           } else if (couponCode.percentOff) {

--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -281,7 +281,6 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
 
         const userUuid = req.user?.payload?.uuid;
         const user = await usersService.findUserByUuid(userUuid).catch(() => null);
-        console.log({ userUuid, customerId: user?.customerId });
 
         const price = await paymentsService.getPriceById(priceId, currency);
         let amount = price.amount;

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -4,7 +4,7 @@ import { DisplayPrice } from '../core/users/DisplayPrice';
 import { ProductsRepository } from '../core/users/ProductsRepository';
 import { User, UserSubscription, UserType } from '../core/users/User';
 import { Bit2MeService } from './bit2me.service';
-import { NotFoundError } from '../errors/Errors';
+import { BadRequestError, NotFoundError } from '../errors/Errors';
 
 type Customer = Stripe.Customer;
 export type CustomerId = Customer['id'];
@@ -1330,6 +1330,12 @@ export class PaymentService {
     return lastActiveCoupon;
   }
 
+  /**
+   *
+   * @param product - The id of the product we want to apply the promo code
+   * @param promoCodeName - The name of the promotion code
+   * @returns The promotion code object
+   */
   async getPromoCodeByName(product: string, promoCodeName: Stripe.PromotionCode['code']): Promise<PromotionCode> {
     const promoCode = await this.getPromoCode(promoCodeName);
 
@@ -1338,7 +1344,7 @@ export class PaymentService {
     const isProductAllowed = promoCodeIsAppliedTo?.find((productId) => productId === product);
 
     if (promoCodeIsAppliedTo && !isProductAllowed) {
-      throw new PromoCodeIsNotValidError(`Promo code ${promoCodeName} is not valid`);
+      throw new BadRequestError(`Promo code ${promoCodeName} is not valid`);
     }
 
     return {

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1343,7 +1343,7 @@ export class PaymentService {
   }
 
   /**
-   *
+   * This function is used to get some information about the promotion code using the code of the Promotion code.
    * @param product - The id of the product we want to apply the promo code
    * @param promoCodeName - The name of the promotion code
    * @returns The promotion code object

--- a/tests/src/controller/checkout.controller.test.ts
+++ b/tests/src/controller/checkout.controller.test.ts
@@ -452,7 +452,7 @@ describe('Checkout controller', () => {
       const mockedTaxes = getTaxes();
 
       jest.spyOn(PaymentService.prototype, 'getPriceById').mockResolvedValue(mockedPrice);
-      jest.spyOn(PaymentService.prototype, 'getTaxForPrice').mockResolvedValue(mockedTaxes);
+      jest.spyOn(PaymentService.prototype, 'calculateTax').mockResolvedValue(mockedTaxes);
 
       const response = await app.inject({
         path: `/checkout/price-by-id?priceId=${mockedPrice.id}`,
@@ -491,7 +491,7 @@ describe('Checkout controller', () => {
 
       jest.spyOn(PaymentService.prototype, 'getPriceById').mockResolvedValue(mockedPrice);
       jest.spyOn(PaymentService.prototype, 'getPromoCodeByName').mockResolvedValue(promoCode);
-      jest.spyOn(PaymentService.prototype, 'getTaxForPrice').mockResolvedValue(mockedTaxes);
+      jest.spyOn(PaymentService.prototype, 'calculateTax').mockResolvedValue(mockedTaxes);
 
       const response = await app.inject({
         path: `/checkout/price-by-id?priceId=${mockedPrice.id}&promoCodeName=${promoCode.promoCodeName}`,

--- a/tests/src/controller/payments.controller.test.ts
+++ b/tests/src/controller/payments.controller.test.ts
@@ -95,7 +95,7 @@ describe('Payment controller e2e tests', () => {
           path: `/plan-by-id?planId=${mockedPrice.subscription.exists}`,
           method: 'GET',
         });
-        const responseBody = JSON.parse(response.body);
+        const responseBody = response.json();
 
         expect(response.statusCode).toBe(200);
         expect(responseBody).toMatchObject(expectedKeys);
@@ -133,7 +133,7 @@ describe('Payment controller e2e tests', () => {
           method: 'GET',
         });
 
-        const responseBody = JSON.parse(response.body);
+        const responseBody = response.json();
 
         expect(response.statusCode).toBe(200);
         expect(responseBody).toMatchObject(expectedKeys);
@@ -199,7 +199,7 @@ describe('Payment controller e2e tests', () => {
         query: mockedQuery,
       });
 
-      const responseBody = JSON.parse(response.body);
+      const responseBody = response.json();
 
       expect(response.statusCode).toBe(200);
       expect(responseBody).toStrictEqual(paymentIntentResponse);

--- a/tests/src/controller/payments.controller.test.ts
+++ b/tests/src/controller/payments.controller.test.ts
@@ -4,7 +4,7 @@ import {
   getCustomer,
   getPrice,
   getPrices,
-  getPromotionCode,
+  getPromotionCodeResponse,
   getUniqueCodes,
   getUser,
   getValidAuthToken,
@@ -366,7 +366,7 @@ describe('Payment controller e2e tests', () => {
       it('When promotion code is present, then the subscription should be created with it', async () => {
         const mockedUser = getUser();
         const mockedAuthToken = `Bearer ${getValidAuthToken(mockedUser.uuid)}`;
-        const mockedPromoCodeId = getPromotionCode();
+        const mockedPromoCodeId = getPromotionCodeResponse();
         const token = getValidUserToken(mockedUser.customerId);
 
         const mockedBody = {

--- a/tests/src/fixtures.spec.ts
+++ b/tests/src/fixtures.spec.ts
@@ -14,7 +14,7 @@ import {
   getLogger,
   getPaymentIntentResponse,
   getPrices,
-  getPromotionCode,
+  getPromotionCodeResponse,
   newTier,
   getUniqueCodes,
 } from './fixtures';
@@ -111,14 +111,14 @@ describe('Test fixtures', () => {
 
   describe('Promotion code fixture', () => {
     it('When generating a promotion code, then it should have default values', () => {
-      const promoCode = getPromotionCode({});
+      const promoCode = getPromotionCodeResponse({});
 
       expect(promoCode.codeId).toBe('promo_id');
       expect(promoCode.percentOff).toBe(75);
     });
 
     it('When passing custom parameters, then it should override the defaults', () => {
-      const promoCode = getPromotionCode({ percentOff: 50 });
+      const promoCode = getPromotionCodeResponse({ percentOff: 50 });
 
       expect(promoCode.percentOff).toBe(50);
     });

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -66,7 +66,7 @@ export const getCustomer = (params?: Partial<Stripe.Customer>): Stripe.Customer 
   };
 };
 
-export const getPromotionCode = (params?: Partial<PromotionCode>): PromotionCode => {
+export const getPromotionCodeResponse = (params?: Partial<PromotionCode>): PromotionCode => {
   return {
     codeId: 'promo_id',
     promoCodeName: 'PROMO_NAME',
@@ -151,6 +151,45 @@ export const getTaxes = (): Stripe.Tax.Calculation => {
       },
     ],
     tax_date: 1746705242,
+  };
+};
+
+export const getPromoCode = (params?: Partial<Stripe.PromotionCode>): Stripe.PromotionCode => {
+  return {
+    id: `promo_${randomDataGenerator.string({ length: 22 })}`,
+    object: 'promotion_code',
+    active: true,
+    code: randomDataGenerator.string({ length: 10 }),
+    coupon: {
+      id: randomDataGenerator.string({ length: 10 }),
+      object: 'coupon',
+      amount_off: null,
+      created: 1678040164,
+      currency: null,
+      duration: 'repeating',
+      duration_in_months: 3,
+      livemode: false,
+      max_redemptions: null,
+      metadata: {},
+      name: null,
+      percent_off: 25.5,
+      redeem_by: null,
+      times_redeemed: 0,
+      valid: true,
+    },
+    created: 1678040164,
+    customer: null,
+    expires_at: null,
+    livemode: false,
+    max_redemptions: null,
+    metadata: {},
+    restrictions: {
+      first_time_transaction: false,
+      minimum_amount: null,
+      minimum_amount_currency: null,
+    },
+    times_redeemed: 0,
+    ...params,
   };
 };
 

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -116,7 +116,7 @@ export const getPrices = () => {
   };
 };
 
-export const getTaxes = (): Stripe.Tax.Calculation => {
+export const getTaxes = (params?: Partial<Stripe.Tax.Calculation>): Stripe.Tax.Calculation => {
   return {
     id: 'taxcalc_1RMT1aFAOdcgaBMQEoAm2Pee',
     object: 'tax.calculation',
@@ -151,6 +151,7 @@ export const getTaxes = (): Stripe.Tax.Calculation => {
       },
     ],
     tax_date: 1746705242,
+    ...params,
   };
 };
 

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -177,6 +177,7 @@ export const priceById = ({
     interval,
     decimalAmount: (mockedPrice.currency_options![mockedPrice.currency].unit_amount as number) / 100,
     type,
+    product: mockedPrice.product as string,
     ...businessSeats,
   };
 };

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -495,6 +495,7 @@ describe('Payments Service tests', () => {
         bytes: parseInt(mockedPrice.metadata?.maxSpaceBytes),
         interval: mockedPrice.type === 'one_time' ? 'lifetime' : mockedPrice.recurring?.interval,
         decimalAmount: (mockedPrice.currency_options![mockedPrice.currency].unit_amount as number) / 100,
+        product: mockedPrice.product as string,
         type: UserType.Individual,
       };
       jest.spyOn(paymentService, 'getPricesRaw').mockResolvedValue([mockedPrice]);
@@ -525,6 +526,7 @@ describe('Payments Service tests', () => {
         bytes: parseInt(mockedPrice.metadata?.maxSpaceBytes),
         interval: mockedPrice.type === 'one_time' ? 'lifetime' : mockedPrice.recurring?.interval,
         decimalAmount: (mockedPrice.currency_options![mockedPrice.currency].unit_amount as number) / 100,
+        product: mockedPrice.product as string,
         type: UserType.Business,
         ...businessSeats,
       };

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -547,7 +547,7 @@ describe('Payments Service tests', () => {
         .spyOn(stripe.tax.calculations, 'create')
         .mockResolvedValue(mockedTaxes as Stripe.Response<Stripe.Tax.Calculation>);
 
-      const taxes = await paymentService.getTaxForPrice(mockedPrice.id, mockedPrice.unit_amount as number, 'user_ip');
+      const taxes = await paymentService.calculateTax(mockedPrice.id, mockedPrice.unit_amount as number, 'user_ip');
 
       expect(taxes).toStrictEqual(mockedTaxes);
     });


### PR DESCRIPTION
This PR updates the tax calculation logic during the purchase process to ensure that discounts are correctly accounted for. The main changes include:
* Adjusted the tax calculation to apply discounts before calculating taxes, resulting in accurate tax amounts based on the final price.
* Added functionality to retrieve tax-inclusive product information, allowing for better display of final prices to users.
* Calculate a tax estimate following Stripe's documentation:
   * Customer billing address if exists.
   * IP address if exists
* Calculate final taxes if the customer is new and the IP address and billing address (country) do not match.
* Update fixtures and test cases to reflect the new tax calculation logic and ensure consistency with the adjusted implementation.

## Checklist
- Discounts are applied before tax calculation
- Product information with included taxes is correctly retrieved
- Tests and fixtures have been updated and verified