### PR TITLE
[_]: fix/price in checkout

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -291,10 +291,8 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
             amount = price.amount - couponCode.amountOff;
           } else if (couponCode.percentOff) {
             const percentDiscount = 100 - couponCode.percentOff;
-            const discount = (price.amount * percentDiscount) / 100;
-            amount = discount;
-            price.amount = discount;
-            price.decimalAmount = discount / 100;
+            const discountedPrice = (price.amount * percentDiscount) / 100;
+            amount = discountedPrice;
           }
         }
 

--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -290,8 +290,8 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
           if (couponCode.amountOff) {
             amount = price.amount - couponCode.amountOff;
           } else if (couponCode.percentOff) {
-            const percentDiscount = 100 - couponCode.percentOff;
-            const discountedPrice = (price.amount * percentDiscount) / 100;
+            const discount = Math.floor((price.amount * couponCode.percentOff) / 100);
+            const discountedPrice = price.amount - discount;
             amount = discountedPrice;
           }
         }
@@ -307,11 +307,13 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
         );
 
         return res.status(200).send({
-          ...price,
-          tax: taxForPrice.tax_amount_exclusive,
-          decimalTax: taxForPrice.tax_amount_exclusive / 100,
-          amountWithTax: taxForPrice.amount_total,
-          decimalAmountWithTax: taxForPrice.amount_total / 100,
+          price,
+          taxes: {
+            tax: taxForPrice.tax_amount_exclusive,
+            decimalTax: taxForPrice.tax_amount_exclusive / 100,
+            amountWithTax: taxForPrice.amount_total,
+            decimalAmountWithTax: taxForPrice.amount_total / 100,
+          },
         });
       },
     );

--- a/tests/src/controller/checkout.controller.test.ts
+++ b/tests/src/controller/checkout.controller.test.ts
@@ -466,11 +466,13 @@ describe('Checkout controller', () => {
 
       expect(response.statusCode).toBe(200);
       expect(responseBody).toStrictEqual({
-        ...mockedPrice,
-        tax: mockedTaxes.tax_amount_exclusive,
-        decimalTax: mockedTaxes.tax_amount_exclusive / 100,
-        amountWithTax: mockedTaxes.amount_total,
-        decimalAmountWithTax: mockedTaxes.amount_total / 100,
+        price: mockedPrice,
+        taxes: {
+          tax: mockedTaxes.tax_amount_exclusive,
+          decimalTax: mockedTaxes.tax_amount_exclusive / 100,
+          amountWithTax: mockedTaxes.amount_total,
+          decimalAmountWithTax: mockedTaxes.amount_total / 100,
+        },
       });
     });
 
@@ -506,11 +508,13 @@ describe('Checkout controller', () => {
 
         expect(response.statusCode).toBe(200);
         expect(responseBody).toStrictEqual({
-          ...mockedPrice,
-          tax: mockedTaxes.tax_amount_exclusive,
-          decimalTax: mockedTaxes.tax_amount_exclusive / 100,
-          amountWithTax: mockedTaxes.amount_total,
-          decimalAmountWithTax: mockedTaxes.amount_total / 100,
+          price: mockedPrice,
+          taxes: {
+            tax: mockedTaxes.tax_amount_exclusive,
+            decimalTax: mockedTaxes.tax_amount_exclusive / 100,
+            amountWithTax: mockedTaxes.amount_total,
+            decimalAmountWithTax: mockedTaxes.amount_total / 100,
+          },
         });
       });
 
@@ -546,11 +550,13 @@ describe('Checkout controller', () => {
 
         expect(response.statusCode).toBe(200);
         expect(responseBody).toStrictEqual({
-          ...mockedPrice,
-          tax: mockedTaxes.tax_amount_exclusive,
-          decimalTax: mockedTaxes.tax_amount_exclusive / 100,
-          amountWithTax: mockedTaxes.amount_total,
-          decimalAmountWithTax: mockedTaxes.amount_total / 100,
+          price: mockedPrice,
+          taxes: {
+            tax: mockedTaxes.tax_amount_exclusive,
+            decimalTax: mockedTaxes.tax_amount_exclusive / 100,
+            amountWithTax: mockedTaxes.amount_total,
+            decimalAmountWithTax: mockedTaxes.amount_total / 100,
+          },
         });
       });
     });


### PR DESCRIPTION
This PR updates the GET /price-by-id endpoint to return two structured objects:

Price:
Includes all relevant pricing information:
- `amount`: Base price in cents
- `type`: Either 'individual' or 'business'
- `interval`: 'year' or 'lifetime'
- `decimalAmount`: Price in euros
- `product`: ID of the associated product
- `businessSeats`: Minimum and maximum number of seats required (for business plans)


Taxes:
Contains tax-related details calculated based on the request context:
- `tax`: Tax amount in cents
- `decimalTax`: Tax amount in euros
- `amountWithTax`: Total amount (price + tax) in cents
- `decimalAmountWithTax`: Total amount in euros

With this structure, the frontend has all the necessary information to accurately display pricing and tax breakdowns within the integrated checkout flow.

