### PR TITLE
[_]: feat/use company name if provided to create customer

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -40,7 +40,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
       }
     });
 
-    fastify.get<{ Querystring: { country: string; postalCode: string; companyVatId: string } }>(
+    fastify.get<{ Querystring: { country: string; postalCode: string; companyVatId?: string; companyName?: string } }>(
       '/customer',
       {
         schema: {
@@ -50,6 +50,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
               country: { type: 'string' },
               postalCode: { type: 'string' },
               companyVatId: { type: 'string' },
+              companyName: { type: 'string' },
             },
           },
         },
@@ -62,7 +63,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
       },
       async (req, res): Promise<{ customerId: string; token: string }> => {
         let customerId: Stripe.Customer['id'];
-        const { country, postalCode, companyVatId } = req.query;
+        const { country, postalCode, companyVatId, companyName } = req.query;
         const { uuid: userUuid, email, name } = req.user.payload;
 
         const userExists = await usersService.findUserByUuid(userUuid).catch(() => null);
@@ -71,7 +72,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
           customerId = userExists.customerId;
         } else {
           const { id } = await paymentsService.createCustomer({
-            name,
+            name: companyName ?? name,
             email,
             address: {
               country,


### PR DESCRIPTION
This PR adds a new query parameter to the customer creation endpoint that allows using the user's company name when available.

If the companyName is provided, it will be used as the Stripe customer's name. Otherwise, the user's personal name will be used as a fallback.