### PR TITLE
[_]: fix/customer name query param when creating customer

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -40,13 +40,14 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
       }
     });
 
-    fastify.get<{ Querystring: { name: string; country: string; postalCode: string; companyVatId?: string } }>(
+    fastify.get<{ Querystring: { customerName: string; country: string; postalCode: string; companyVatId?: string } }>(
       '/customer',
       {
         schema: {
           querystring: {
             type: 'object',
             properties: {
+              customerName: { type: 'string' },
               country: { type: 'string' },
               postalCode: { type: 'string' },
               companyVatId: { type: 'string' },
@@ -62,7 +63,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
       },
       async (req, res): Promise<{ customerId: string; token: string }> => {
         let customerId: Stripe.Customer['id'];
-        const { name, country, postalCode, companyVatId } = req.query;
+        const { customerName, country, postalCode, companyVatId } = req.query;
         const { uuid: userUuid, email } = req.user.payload;
 
         const userExists = await usersService.findUserByUuid(userUuid).catch(() => null);
@@ -72,7 +73,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
             userExists.customerId,
             {
               customer: {
-                name,
+                name: customerName,
               },
             },
             {
@@ -85,7 +86,7 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
           customerId = userExists.customerId;
         } else {
           const { id } = await paymentsService.createCustomer({
-            name: name,
+            name: customerName,
             email,
             address: {
               country,

--- a/tests/src/controller/checkout.controller.test.ts
+++ b/tests/src/controller/checkout.controller.test.ts
@@ -460,6 +460,11 @@ describe('Checkout controller', () => {
   });
 
   describe('Get Price by its ID', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
+
     it('When the user wants to get a price by its ID, then the price is returned with its taxes', async () => {
       const mockedPrice = priceById({
         bytes: 123456789,
@@ -512,9 +517,6 @@ describe('Checkout controller', () => {
         const response = await app.inject({
           path: `/checkout/price-by-id?priceId=${mockedPrice.id}&promoCodeName=${promoCode.promoCodeName}&userAddress=123.12.12.12`,
           method: 'GET',
-          headers: {
-            'X-Real-Ip': 'user-ip',
-          },
         });
 
         const responseBody = response.json();
@@ -554,9 +556,6 @@ describe('Checkout controller', () => {
         const response = await app.inject({
           path: `/checkout/price-by-id?priceId=${mockedPrice.id}&promoCodeName=${promoCode.promoCodeName}&userAddress=123.12.12.12`,
           method: 'GET',
-          headers: {
-            'X-Real-Ip': 'user-ip',
-          },
         });
 
         const responseBody = response.json();


### PR DESCRIPTION
This PR uses the correct customer name query parameter sent from the client side.