### PR TITLE
[PB-4396]: feat/function to handle the captured funds

### DIFF
--- a/src/errors/Errors.ts
+++ b/src/errors/Errors.ts
@@ -30,6 +30,12 @@ export class ForbiddenError extends HttpError {
   }
 }
 
+export class GoneError extends HttpError {
+  constructor(message = 'Gone') {
+    super(message, 410);
+  }
+}
+
 export class InternalServerError extends HttpError {
   constructor(message = 'Internal Server Error') {
     super(message, 500);

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1641,19 +1641,6 @@ export class PaymentService {
     return renewalPeriod;
   }
 
-  /**
-   * This function is used to fetch the product storage product
-   * @returns the Object Storage product stored in Products collection
-   */
-  async getObjectStorageProduct() {
-    const objectStorage = await this.productsRepository.findByType(UserType.ObjectStorage);
-    if (objectStorage.length === 0) {
-      throw new NotFoundError('There is no object storage product');
-    }
-
-    return objectStorage[0];
-  }
-
   async billCardVerificationCharge(customerId: string, currency: string, paymentMethodId?: PaymentMethod['id']) {
     const methods = paymentMethodId
       ? [

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1641,6 +1641,19 @@ export class PaymentService {
     return renewalPeriod;
   }
 
+  /**
+   * This function is used to fetch the product storage product
+   * @returns the Object Storage product stored in Products collection
+   */
+  async getObjectStorageProduct() {
+    const objectStorage = await this.productsRepository.findByType(UserType.ObjectStorage);
+    if (objectStorage.length === 0) {
+      throw new NotFoundError('There is no object storage product');
+    }
+
+    return objectStorage[0];
+  }
+
   async billCardVerificationCharge(customerId: string, currency: string, paymentMethodId?: PaymentMethod['id']) {
     const methods = paymentMethodId
       ? [

--- a/src/webhooks/handleFundsCaptured.ts
+++ b/src/webhooks/handleFundsCaptured.ts
@@ -1,0 +1,59 @@
+import Stripe from 'stripe';
+import { FastifyBaseLogger } from 'fastify';
+
+import { PaymentService } from '../services/payment.service';
+import { ObjectStorageService } from '../services/objectStorage.service';
+import { BadRequestError, GoneError } from '../errors/Errors';
+
+function isCustomer(customer: Stripe.Customer | Stripe.DeletedCustomer): customer is Stripe.Customer {
+  return !customer.deleted;
+}
+
+export default async function handleFundsCaptured(
+  paymentIntent: Stripe.PaymentIntent,
+  paymentsService: PaymentService,
+  objectStorageService: ObjectStorageService,
+  stripe: Stripe,
+  logger: FastifyBaseLogger,
+): Promise<void> {
+  if (!paymentIntent.metadata.type || paymentIntent.metadata.type !== 'object-storage') {
+    return;
+  }
+
+  logger.info(`Received successful payment intent ${paymentIntent.id} from customer ${paymentIntent.customer}`);
+
+  const customer = await paymentsService.getCustomer(paymentIntent.customer as string);
+
+  if (!isCustomer(customer)) {
+    throw new GoneError(`Customer ${paymentIntent.customer} has been deleted`);
+  }
+
+  if (!customer.email) {
+    throw new BadRequestError(`Customer ${paymentIntent.customer} has no email`);
+  }
+
+  logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) is being initialized...`);
+
+  await stripe.paymentIntents.cancel(paymentIntent.id);
+
+  const products = await paymentsService.getObjectStorageProduct();
+
+  await paymentsService.createSubscription({
+    customerId: customer.id,
+    priceId: products.paymentGatewayId,
+    additionalOptions: {
+      default_payment_method: paymentIntent.payment_method as string,
+      off_session: true,
+      automatic_tax: {
+        enabled: true,
+      },
+    },
+  });
+
+  await objectStorageService.initObjectStorageUser({
+    email: customer.email,
+    customerId: customer.id,
+  });
+
+  logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) has been initialized!`);
+}

--- a/src/webhooks/handleFundsCaptured.ts
+++ b/src/webhooks/handleFundsCaptured.ts
@@ -16,7 +16,11 @@ export default async function handleFundsCaptured(
   stripe: Stripe,
   logger: FastifyBaseLogger,
 ): Promise<void> {
-  if (!paymentIntent.metadata.type || paymentIntent.metadata.type !== 'object-storage') {
+  if (
+    !paymentIntent.metadata.type ||
+    paymentIntent.metadata.type !== 'object-storage' ||
+    !paymentIntent.metadata.priceId
+  ) {
     return;
   }
 
@@ -36,11 +40,9 @@ export default async function handleFundsCaptured(
 
   await stripe.paymentIntents.cancel(paymentIntent.id);
 
-  const products = await paymentsService.getObjectStorageProduct();
-
   await paymentsService.createSubscription({
     customerId: customer.id,
-    priceId: products.paymentGatewayId,
+    priceId: paymentIntent.metadata.priceId,
     additionalOptions: {
       default_payment_method: paymentIntent.payment_method as string,
       off_session: true,

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -566,6 +566,69 @@ export const getPaymentIntentResponse = (params?: Partial<PaymentIntent>): Payme
   };
 };
 
+export const getPaymentIntent = (params?: Partial<Stripe.PaymentIntent>): Stripe.PaymentIntent => {
+  return {
+    id: `pi_${randomDataGenerator.string({ length: 14 })}`,
+    invoice: `in_${randomDataGenerator.string({ length: 14 })}`,
+    payment_method_configuration_details: {
+      id: '',
+      parent: '',
+    },
+    object: 'payment_intent',
+    amount: 2000,
+    amount_capturable: 0,
+    amount_details: {
+      tip: {},
+    },
+    amount_received: 0,
+    application: null,
+    application_fee_amount: null,
+    automatic_payment_methods: {
+      enabled: true,
+    },
+    canceled_at: null,
+    cancellation_reason: null,
+    capture_method: 'automatic',
+    client_secret: `pi_${randomDataGenerator.string({ length: 24 })}`,
+    confirmation_method: 'automatic',
+    created: 1680800504,
+    currency: 'usd',
+    customer: null,
+    description: null,
+    last_payment_error: null,
+    latest_charge: null,
+    livemode: false,
+    metadata: {},
+    next_action: null,
+    on_behalf_of: null,
+    payment_method: null,
+    payment_method_options: {
+      card: {
+        installments: null,
+        mandate_options: null,
+        network: null,
+        request_three_d_secure: 'automatic',
+      },
+      link: {
+        persistent_token: null,
+      },
+    },
+    payment_method_types: ['card', 'link'],
+    processing: null,
+    receipt_email: null,
+    review: null,
+    setup_future_usage: null,
+    shipping: null,
+    source: null,
+    statement_descriptor: null,
+    statement_descriptor_suffix: null,
+    status: 'requires_payment_method',
+    transfer_data: null,
+    transfer_group: null,
+    ...params,
+  };
+};
+
 export const getCoupon = (params?: Partial<Coupon>): Coupon => ({
   id: randomUUID(),
   provider: 'stripe',


### PR DESCRIPTION
This PR adds logic to handle the event triggered after payment method verification when Stripe captures the funds.

When Stripe confirms that the payment method has sufficient funds (by capturing 1 €), the PaymentIntent is immediately cancelled to avoid charging the user. Then, the object storage subscription is created and the associated account is initialized.

This flow ensures the payment method is valid without incurring fees or creating subscriptions with invalid payment sources.