### PR TITLE
[PB-4396]: feat/add event to create subscription and initialize object-storage 

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 export const HUNDRED_TB = 109951162777600;
 export const FREE_PLAN_BYTES_SPACE = 1 * 1024 * 1024 * 1024;
 export const FREE_INDIVIDUAL_TIER = 'free_individual_tier';
+export const VERIFICATION_CHARGE = 100;

--- a/src/webhooks/handleFundsCaptured.ts
+++ b/src/webhooks/handleFundsCaptured.ts
@@ -3,7 +3,10 @@ import { FastifyBaseLogger } from 'fastify';
 
 import { PaymentService } from '../services/payment.service';
 import { ObjectStorageService } from '../services/objectStorage.service';
-import { BadRequestError, GoneError } from '../errors/Errors';
+import { BadRequestError, ConflictError, GoneError } from '../errors/Errors';
+import { UserType } from '../core/users/User';
+import axios from 'axios';
+import { VERIFICATION_CHARGE } from '../constants';
 
 function isCustomer(customer: Stripe.Customer | Stripe.DeletedCustomer): customer is Stripe.Customer {
   return !customer.deleted;
@@ -16,46 +19,76 @@ export default async function handleFundsCaptured(
   stripe: Stripe,
   logger: FastifyBaseLogger,
 ): Promise<void> {
-  if (
-    !paymentIntent.metadata.type ||
-    paymentIntent.metadata.type !== 'object-storage' ||
-    !paymentIntent.metadata.priceId
-  ) {
+  const isMissingType = !paymentIntent.metadata.type;
+  const isNotObjectStorage = paymentIntent.metadata.type !== 'object-storage';
+  const isMissingPriceId = !paymentIntent.metadata.priceId;
+  const isFullVerificationChargeCaptured = paymentIntent.amount_received === VERIFICATION_CHARGE;
+
+  const shouldSkipHandling =
+    isMissingType || isNotObjectStorage || isMissingPriceId || isFullVerificationChargeCaptured;
+
+  if (shouldSkipHandling) {
     return;
   }
 
-  logger.info(`Received successful payment intent ${paymentIntent.id} from customer ${paymentIntent.customer}`);
+  logger.info(
+    `Received successful payment intent ${paymentIntent.id} from customer ${paymentIntent.customer as string}`,
+  );
 
   const customer = await paymentsService.getCustomer(paymentIntent.customer as string);
 
   if (!isCustomer(customer)) {
-    throw new GoneError(`Customer ${paymentIntent.customer} has been deleted`);
+    throw new GoneError(`Customer ${paymentIntent.customer as string} has been deleted`);
   }
 
   if (!customer.email) {
-    throw new BadRequestError(`Customer ${paymentIntent.customer} has no email`);
+    throw new BadRequestError(`Customer ${paymentIntent.customer as string} has no email`);
   }
 
   logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) is being initialized...`);
 
-  await stripe.paymentIntents.cancel(paymentIntent.id);
+  const isPaymentIntentCanceled = paymentIntent.status === 'canceled';
 
-  await paymentsService.createSubscription({
-    customerId: customer.id,
-    priceId: paymentIntent.metadata.priceId,
-    additionalOptions: {
-      default_payment_method: paymentIntent.payment_method as string,
-      off_session: true,
-      automatic_tax: {
-        enabled: true,
+  if (!isPaymentIntentCanceled) {
+    await stripe.paymentIntents.cancel(paymentIntent.id);
+  }
+
+  const { type } = await paymentsService.getUserSubscription(customer.id, UserType.ObjectStorage);
+  const isSubscriptionActivated = type === 'subscription';
+
+  if (!isSubscriptionActivated) {
+    await paymentsService.createSubscription({
+      customerId: customer.id,
+      priceId: paymentIntent.metadata.priceId,
+      additionalOptions: {
+        default_payment_method: paymentIntent.payment_method as string,
+        off_session: true,
+        automatic_tax: {
+          enabled: true,
+        },
       },
-    },
-  });
+    });
+  }
 
-  await objectStorageService.initObjectStorageUser({
-    email: customer.email,
-    customerId: customer.id,
-  });
+  try {
+    await objectStorageService.initObjectStorageUser({
+      email: customer.email,
+      customerId: customer.id,
+    });
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const { status, data } = error.response;
+
+      if (status === ConflictError.prototype.statusCode) {
+        logger.info('The user already has an Object Storage account activated');
+        return;
+      }
+
+      logger.error(`Unexpected error from Object Storage service [status=${status}]: ${JSON.stringify(data)}`);
+    }
+
+    throw error;
+  }
 
   logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) has been initialized!`);
 }

--- a/src/webhooks/handleFundsCaptured.ts
+++ b/src/webhooks/handleFundsCaptured.ts
@@ -79,9 +79,9 @@ export default async function handleFundsCaptured(
     if (axios.isAxiosError(error) && error.response) {
       const { status, data } = error.response;
 
-      if (status === ConflictError.prototype.statusCode) {
+      if (status === 409) {
         logger.info('The user already has an Object Storage account activated');
-        return;
+        throw new ConflictError(error.message);
       }
 
       logger.error(`Unexpected error from Object Storage service [status=${status}]: ${JSON.stringify(data)}`);

--- a/src/webhooks/handleInvoicePaymentFailed.ts
+++ b/src/webhooks/handleInvoicePaymentFailed.ts
@@ -18,8 +18,9 @@ async function findObjectStorageLineItem(
   for (const line of invoice.lines.data) {
     const price = line.price;
     if (!price?.product) continue;
+    const productId = typeof price.product === 'string' ? price.product : price.product.id;
 
-    const product = await paymentService.getProduct(price.product as string);
+    const product = await paymentService.getProduct(productId);
     if (isProduct(product)) return line;
   }
 

--- a/tests/src/webhooks/webhook.test.ts
+++ b/tests/src/webhooks/webhook.test.ts
@@ -1,0 +1,61 @@
+import { FastifyInstance } from 'fastify';
+import { closeServerAndDatabase, initializeServerAndDatabase } from '../utils/initializeServer';
+import Stripe from 'stripe';
+import { getLogger, getPaymentIntent } from '../fixtures';
+import handleFundsCaptured from '../../../src/webhooks/handleFundsCaptured';
+import { PaymentService } from '../../../src/services/payment.service';
+import { ObjectStorageService } from '../../../src/services/objectStorage.service';
+
+let app: FastifyInstance;
+
+jest.mock('../../../src/webhooks/handleFundsCaptured');
+
+beforeAll(async () => {
+  app = await initializeServerAndDatabase();
+  process.env.STRIPE_WEBHOOK_KEY = 'whsec_lorim_ipsum_etc_etc';
+});
+
+afterAll(async () => {
+  await closeServerAndDatabase();
+});
+
+describe('Webhook events', () => {
+  describe('The webhooks are called correctly', () => {
+    it('When the event payment_intent.amount_capturable_updated is triggered, then the correct function is called', async () => {
+      const logger = getLogger();
+      const mockedPaymentIntent = getPaymentIntent();
+      const event = {
+        id: 'evt_1',
+        type: 'payment_intent.amount_capturable_updated',
+        data: { object: mockedPaymentIntent },
+      };
+      const payloadToString = JSON.stringify(event);
+      const secret = 'whsec_lorim_ipsum_etc_etc';
+
+      const header = Stripe.webhooks.generateTestHeaderString({
+        payload: payloadToString,
+        secret,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        path: 'webhook',
+        body: Buffer.from(payloadToString),
+        headers: {
+          'stripe-signature': header,
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(handleFundsCaptured).toHaveBeenCalled();
+      expect(handleFundsCaptured).toHaveBeenCalledWith(
+        event.data.object,
+        expect.any(PaymentService),
+        expect.any(ObjectStorageService),
+        expect.any(Stripe),
+        app.log,
+      );
+    });
+  });
+});

--- a/tests/src/webhooks/webhook.test.ts
+++ b/tests/src/webhooks/webhook.test.ts
@@ -1,14 +1,18 @@
 import { FastifyInstance } from 'fastify';
 import { closeServerAndDatabase, initializeServerAndDatabase } from '../utils/initializeServer';
 import Stripe from 'stripe';
-import { getLogger, getPaymentIntent } from '../fixtures';
+import { getInvoice, getPaymentIntent } from '../fixtures';
 import handleFundsCaptured from '../../../src/webhooks/handleFundsCaptured';
 import { PaymentService } from '../../../src/services/payment.service';
 import { ObjectStorageService } from '../../../src/services/objectStorage.service';
+import handleInvoicePaymentFailed from '../../../src/webhooks/handleInvoicePaymentFailed';
 
 let app: FastifyInstance;
 
 jest.mock('../../../src/webhooks/handleFundsCaptured');
+jest.mock('../../../src/webhooks/handleInvoicePaymentFailed');
+
+const secret = 'whsec_lorim_ipsum_etc_etc';
 
 beforeAll(async () => {
   app = await initializeServerAndDatabase();
@@ -22,7 +26,6 @@ afterAll(async () => {
 describe('Webhook events', () => {
   describe('The webhooks are called correctly', () => {
     it('When the event payment_intent.amount_capturable_updated is triggered, then the correct function is called', async () => {
-      const logger = getLogger();
       const mockedPaymentIntent = getPaymentIntent();
       const event = {
         id: 'evt_1',
@@ -30,7 +33,6 @@ describe('Webhook events', () => {
         data: { object: mockedPaymentIntent },
       };
       const payloadToString = JSON.stringify(event);
-      const secret = 'whsec_lorim_ipsum_etc_etc';
 
       const header = Stripe.webhooks.generateTestHeaderString({
         payload: payloadToString,
@@ -54,6 +56,40 @@ describe('Webhook events', () => {
         expect.any(PaymentService),
         expect.any(ObjectStorageService),
         expect.any(Stripe),
+        app.log,
+      );
+    });
+
+    it('When the event invoice.payment_failed is triggered, then the correct function is called', async () => {
+      const mockedInvoice = getInvoice();
+      const event = {
+        id: 'evt_2',
+        type: 'invoice.payment_failed',
+        data: { object: mockedInvoice },
+      };
+      const payloadToString = JSON.stringify(event);
+
+      const header = Stripe.webhooks.generateTestHeaderString({
+        payload: payloadToString,
+        secret,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        path: 'webhook',
+        body: Buffer.from(payloadToString),
+        headers: {
+          'stripe-signature': header,
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(handleInvoicePaymentFailed).toHaveBeenCalled();
+      expect(handleInvoicePaymentFailed).toHaveBeenCalledWith(
+        event.data.object,
+        expect.any(ObjectStorageService),
+        expect.any(PaymentService),
         app.log,
       );
     });


### PR DESCRIPTION
## What
Add handling for Stripe’s `payment_intent.amount_capturable_updated` webhook that fires when the €1 card-verification hold becomes capturable.

## Why
If we do nothing, Stripe will settle that €1 as an actual charge a few days later. Voiding the intent keeps onboarding friction-free and prevents surprise charges.

## How
- Listen for `payment_intent.amount_capturable_updated`.
- Immediately cancel the Payment Intent, voiding the €1 hold.
- Create the Object-Storage subscription.
- Initilize the customer’s Object-Storage.