### PR TITLE
[_]: refactor/move all endpoint to separated controller

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import fastifyCors from '@fastify/cors';
 import Fastify, { FastifyInstance } from 'fastify';
 import { AppConfig } from './config';
 import controller from './controller/payments.controller';
+import objStorageController from './controller/object-storage.controller';
 import businessController from './controller/business.controller';
 import productsController from './controller/products.controller';
 import checkoutController from './controller/checkout.controller';
@@ -51,6 +52,7 @@ export async function buildApp(
   registerErrorHandler(fastify);
 
   fastify.register(controller(paymentService, usersService, config, cacheService, licenseCodesService, tiersService));
+  fastify.register(objStorageController(paymentService), { prefix: '/object-storage' });
   fastify.register(businessController(paymentService, usersService, config), { prefix: '/business' });
   fastify.register(productsController(tiersService, usersService, productsService, config), { prefix: '/products' });
   fastify.register(checkoutController(usersService, paymentService), { prefix: '/checkout' });

--- a/src/controller/object-storage.controller.ts
+++ b/src/controller/object-storage.controller.ts
@@ -1,0 +1,230 @@
+import { FastifyInstance } from 'fastify';
+import jwt from 'jsonwebtoken';
+import fastifyJwt from '@fastify/jwt';
+import fastifyRateLimit from '@fastify/rate-limit';
+
+import {
+  CustomerNotFoundError,
+  ExistingSubscriptionError,
+  NotFoundPlanByIdError,
+  PaymentService,
+} from '../services/payment.service';
+import { ForbiddenError, UnauthorizedError } from '../errors/Errors';
+import config from '../config';
+import Stripe from 'stripe';
+
+function signUserToken(customerId: string) {
+  return jwt.sign({ customerId }, config.JWT_SECRET);
+}
+
+export default function (paymentService: PaymentService) {
+  return async function (fastify: FastifyInstance) {
+    fastify.register(fastifyJwt, { secret: config.JWT_SECRET });
+    fastify.register(fastifyRateLimit, {
+      max: 1000,
+      timeWindow: '1 minute',
+    });
+
+    fastify.addHook('onRequest', async (request) => {
+      const skipAuth = request.routeOptions?.config?.skipAuth;
+      const allowAnonymous = request.routeOptions?.config?.allowAnonymous;
+
+      if (skipAuth) {
+        return;
+      }
+      try {
+        await request.jwtVerify();
+      } catch (err) {
+        if (allowAnonymous) {
+          return;
+        }
+        request.log.warn(`JWT verification failed with error: ${(err as Error).message}`);
+        throw new UnauthorizedError();
+      }
+    });
+
+    fastify.get<{
+      Querystring: { email: string; customerName: string; country: string; postalCode: string; companyVatId?: string };
+    }>(
+      '/customer',
+      {
+        schema: {
+          querystring: {
+            type: 'object',
+            required: ['email', 'customerName', 'country', 'postalCode'],
+            properties: {
+              email: { type: 'string' },
+              customerName: { type: 'string' },
+              country: { type: 'string' },
+              postalCode: { type: 'string' },
+              companyVatId: { type: 'string' },
+            },
+          },
+        },
+        config: {
+          rateLimit: {
+            max: 5,
+            timeWindow: '1 hour',
+          },
+          skipAuth: true,
+        },
+      },
+      async (req, res) => {
+        let customerId: Stripe.Customer['id'];
+        const { email, customerName, country, postalCode, companyVatId } = req.query;
+
+        const userExists = await paymentService.getCustomerIdByEmail(email).catch((err) => {
+          if (err instanceof CustomerNotFoundError) {
+            return null;
+          }
+
+          throw err;
+        });
+
+        if (userExists) {
+          customerId = userExists.id;
+        } else {
+          const { id } = await paymentService.createCustomer({
+            name: customerName,
+            email,
+            address: {
+              country,
+              postal_code: postalCode,
+            },
+          });
+
+          if (country && companyVatId) {
+            await paymentService.getVatIdAndAttachTaxIdToCustomer(id, country, companyVatId);
+          }
+
+          customerId = id;
+        }
+
+        return res.send({ customerId, token: signUserToken(customerId) });
+      },
+    );
+
+    fastify.post<{
+      Body: {
+        customerId: string;
+        priceId: string;
+        currency: string;
+        token: string;
+        promoCodeId?: string;
+      };
+    }>(
+      '/subscription',
+      {
+        schema: {
+          body: {
+            type: 'object',
+            required: ['customerId', 'priceId', 'token'],
+            properties: {
+              customerId: {
+                type: 'string',
+              },
+              priceId: {
+                type: 'string',
+              },
+              token: {
+                type: 'string',
+              },
+              currency: {
+                type: 'string',
+              },
+              promoCodeId: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        config: {
+          skipAuth: true,
+        },
+      },
+      async (req, res) => {
+        const { customerId, priceId, currency, token, promoCodeId } = req.body;
+
+        try {
+          const payload = jwt.verify(token, config.JWT_SECRET) as {
+            customerId: string;
+          };
+          const tokenCustomerId = payload.customerId;
+
+          if (customerId !== tokenCustomerId) {
+            throw new ForbiddenError();
+          }
+        } catch {
+          throw new ForbiddenError();
+        }
+
+        try {
+          const createdSubscription = await paymentService.createSubscription({
+            customerId,
+            priceId,
+            currency,
+            promoCodeId,
+            additionalOptions: {
+              automatic_tax: {
+                enabled: true,
+              },
+            },
+          });
+
+          return res.send(createdSubscription);
+        } catch (err) {
+          const error = err as Error;
+          if (error instanceof ExistingSubscriptionError) {
+            return res.status(409).send({
+              message: error.message,
+            });
+          }
+
+          req.log.error(`[ERROR CREATING SUBSCRIPTION]: ${error.stack ?? error.message}`);
+
+          return res.status(500).send({
+            message: 'Internal Server Error',
+          });
+        }
+      },
+    );
+
+    fastify.get<{
+      Querystring: { planId: string; currency?: string };
+    }>(
+      '/price',
+      {
+        schema: {
+          querystring: {
+            type: 'object',
+            properties: { planId: { type: 'string' }, currency: { type: 'string' } },
+          },
+        },
+        config: {
+          rateLimit: {
+            max: 5,
+            timeWindow: '1 minute',
+          },
+          skipAuth: true,
+        },
+      },
+      async (req, rep) => {
+        const { planId, currency } = req.query;
+
+        try {
+          const planObject = await paymentService.getObjectStoragePlanById(planId, currency);
+
+          return rep.status(200).send(planObject);
+        } catch (error) {
+          const err = error as Error;
+          if (err instanceof NotFoundPlanByIdError) {
+            return rep.status(404).send({ message: err.message });
+          }
+
+          req.log.error(`[ERROR WHILE FETCHING PLAN BY ID]: ${err.message}. STACK ${err.stack ?? 'NO STACK'}`);
+          return rep.status(500).send({ message: 'Internal Server Error' });
+        }
+      },
+    );
+  };
+}

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -87,69 +87,6 @@ export default function (
       }
     });
 
-    fastify.get<{
-      Querystring: { email: string; customerName: string; country: string; postalCode: string; companyVatId?: string };
-    }>(
-      '/object-storage/customer',
-      {
-        schema: {
-          querystring: {
-            type: 'object',
-            required: ['email', 'customerName', 'country', 'postalCode'],
-            properties: {
-              email: { type: 'string' },
-              customerName: { type: 'string' },
-              country: { type: 'string' },
-              postalCode: { type: 'string' },
-              companyVatId: { type: 'string' },
-            },
-          },
-        },
-        config: {
-          rateLimit: {
-            max: 5,
-            timeWindow: '1 hour',
-          },
-          skipAuth: true,
-        },
-      },
-      async (req, res) => {
-        let customerId: Stripe.Customer['id'];
-        const { email, customerName, country, postalCode, companyVatId } = req.query;
-
-        const userExists = await paymentService.getCustomerIdByEmail(email).catch((err) => {
-          if (err instanceof CustomerNotFoundError) {
-            return null;
-          }
-
-          throw err;
-        });
-
-        if (userExists) {
-          customerId = userExists.id;
-        } else {
-          const { id } = await paymentService.createCustomer({
-            name: customerName,
-            email,
-            address: {
-              country,
-              postal_code: postalCode,
-            },
-          });
-
-          if (country && companyVatId) {
-            await paymentService.getVatIdAndAttachTaxIdToCustomer(id, country, companyVatId);
-          }
-
-          customerId = id;
-        }
-
-        const token = jwt.sign({ customerId }, config.JWT_SECRET);
-
-        return res.send({ customerId, token });
-      },
-    );
-
     fastify.post<{ Body: { name: string; email: string; country?: string; companyVatId?: string } }>(
       '/create-customer',
       {
@@ -353,91 +290,6 @@ export default function (
               message: error.message,
             });
           }
-
-          return res.status(500).send({
-            message: 'Internal Server Error',
-          });
-        }
-      },
-    );
-
-    fastify.post<{
-      Body: {
-        customerId: string;
-        priceId: string;
-        currency: string;
-        token: string;
-        promoCodeId?: string;
-      };
-    }>(
-      '/object-storage/subscription',
-      {
-        schema: {
-          body: {
-            type: 'object',
-            required: ['customerId', 'priceId', 'token'],
-            properties: {
-              customerId: {
-                type: 'string',
-              },
-              priceId: {
-                type: 'string',
-              },
-              token: {
-                type: 'string',
-              },
-              currency: {
-                type: 'string',
-              },
-              promoCodeId: {
-                type: 'string',
-              },
-            },
-          },
-        },
-        config: {
-          skipAuth: true,
-        },
-      },
-      async (req, res) => {
-        const { customerId, priceId, currency, token, promoCodeId } = req.body;
-
-        try {
-          const payload = jwt.verify(token, config.JWT_SECRET) as {
-            customerId: string;
-          };
-          const tokenCustomerId = payload.customerId;
-
-          if (customerId !== tokenCustomerId) {
-            throw new ForbiddenError();
-          }
-        } catch {
-          throw new ForbiddenError();
-        }
-
-        try {
-          const createdSubscription = await paymentService.createSubscription({
-            customerId,
-            priceId,
-            currency,
-            promoCodeId,
-            additionalOptions: {
-              automatic_tax: {
-                enabled: true,
-              },
-            },
-          });
-
-          return res.send(createdSubscription);
-        } catch (err) {
-          const error = err as Error;
-          if (error instanceof ExistingSubscriptionError) {
-            return res.status(409).send({
-              message: error.message,
-            });
-          }
-
-          req.log.error(`[ERROR CREATING SUBSCRIPTION]: ${error.stack ?? error.message}`);
 
           return res.status(500).send({
             message: 'Internal Server Error',
@@ -1212,44 +1064,6 @@ export default function (
         return rep.status(500).send({ message: 'Internal Server Error' });
       }
     });
-
-    fastify.get<{
-      Querystring: { planId: string; currency?: string };
-    }>(
-      '/object-storage/price',
-      {
-        schema: {
-          querystring: {
-            type: 'object',
-            properties: { planId: { type: 'string' }, currency: { type: 'string' } },
-          },
-        },
-        config: {
-          rateLimit: {
-            max: 5,
-            timeWindow: '1 minute',
-          },
-          skipAuth: true,
-        },
-      },
-      async (req, rep) => {
-        const { planId, currency } = req.query;
-
-        try {
-          const planObject = await paymentService.getObjectStoragePlanById(planId, currency);
-
-          return rep.status(200).send(planObject);
-        } catch (error) {
-          const err = error as Error;
-          if (err instanceof NotFoundPlanByIdError) {
-            return rep.status(404).send({ message: err.message });
-          }
-
-          req.log.error(`[ERROR WHILE FETCHING PLAN BY ID]: ${err.message}. STACK ${err.stack ?? 'NO STACK'}`);
-          return rep.status(500).send({ message: 'Internal Server Error' });
-        }
-      },
-    );
 
     fastify.get<{
       Querystring: { promotionCode: string };


### PR DESCRIPTION
All routes are now served under the common /object-storage prefix to improve clarity, maintainability, and consistency across the API surface.