### PR TITLE
[_]: chore/action to stale and close inactive PRs

### DIFF
--- a/.github/workflows/close-inactive-pr.yml
+++ b/.github/workflows/close-inactive-pr.yml
@@ -1,0 +1,23 @@
+name: 'Closing inactive PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity. It will be closed in 7 days if no further updates are made.'
+          close-pr-message: 'This pull request has been automatically closed due to prolonged inactivity.'
+          stale-pr-label: 'stalled'
+          exempt-draft-pr: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new GitHub Action that runs daily to automatically manage inactive pull requests.
If a pull request has had no activity for 30 days, it will be labeled as Stalled and a comment will be added to notify contributors.
If there is no further activity within the next 7 days after being marked as stalled, the PR will be automatically closed.