### PR TITLE
[PB 4719]: feature/apply tier if necessary when redeeming the code

### DIFF
--- a/src/cli/load-license-codes.ts
+++ b/src/cli/load-license-codes.ts
@@ -96,13 +96,13 @@ async function main() {
       storageService,
       envVariablesConfig,
     );
-    const licenseCodesService = new LicenseCodesService(
+    const licenseCodesService = new LicenseCodesService({
       paymentService,
       usersService,
       storageService,
       licenseCodesRepository,
       tiersService,
-    );
+    });
 
     for (const licenseCode of loadFromExcel()) {
       await licenseCodesService.insertLicenseCode(licenseCode);

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -1246,7 +1246,7 @@ export default function (
         const { code, provider } = req.body;
 
         try {
-          await licenseCodesService.redeem({ email, uuid, name: `${name} ${lastname}` }, code, provider);
+          await licenseCodesService.redeem({ email, uuid, name: `${name} ${lastname}` }, code, provider, req.log);
 
           return rep.status(200).send({ message: 'Code redeemed' });
         } catch (error) {

--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -1246,7 +1246,12 @@ export default function (
         const { code, provider } = req.body;
 
         try {
-          await licenseCodesService.redeem({ email, uuid, name: `${name} ${lastname}` }, code, provider, req.log);
+          await licenseCodesService.redeem({
+            user: { email, uuid, name: `${name} ${lastname}` },
+            code,
+            provider,
+            logger: req.log,
+          });
 
           return rep.status(200).send({ message: 'Code redeemed' });
         } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,13 +64,13 @@ const start = async (mongoTestClient?: MongoClient): Promise<FastifyInstance> =>
     storageService,
     envVariablesConfig,
   );
-  const licenseCodesService = new LicenseCodesService(
+  const licenseCodesService = new LicenseCodesService({
     paymentService,
     usersService,
     storageService,
     licenseCodesRepository,
     tiersService,
-  );
+  });
   const objectStorageService = new ObjectStorageService(paymentService, envVariablesConfig, axios);
 
   const productsService = new ProductsService(tiersService, usersService);

--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -76,16 +76,21 @@ export class LicenseCodesService {
     return true;
   }
 
-  async redeem(
+  async redeem({
+    user,
+    code,
+    provider,
+    logger,
+  }: {
     user: {
       email: string;
       uuid: User['uuid'];
       name?: string;
-    },
-    code: LicenseCode['code'],
-    provider: LicenseCode['provider'],
-    logger: FastifyBaseLogger,
-  ): Promise<void> {
+    };
+    code: LicenseCode['code'];
+    provider: LicenseCode['provider'];
+    logger: FastifyBaseLogger;
+  }): Promise<void> {
     const licenseCode = await this.licenseCodesRepository.findOne(code, provider);
 
     if (licenseCode === null) {

--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -157,7 +157,7 @@ export class LicenseCodesService {
     return tierProduct;
   }
 
-  private async applyProductFeatures({
+  async applyProductFeatures({
     user,
     customer,
     logger,

--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -17,6 +17,14 @@ type LicenseCodesServiceDeps = {
   tiersService: TiersService;
 };
 
+interface ApplyProductFeaturesProps {
+  user: { uuid: string; email: string };
+  customer: Stripe.Customer;
+  logger: FastifyBaseLogger;
+  maxSpaceBytes: number;
+  tierProduct: Tier | null;
+}
+
 export class InvalidLicenseCodeError extends Error {
   constructor() {
     super('Invalid code provided');
@@ -34,13 +42,25 @@ export class LicenseCodeAlreadyAppliedError extends Error {
 }
 
 export class LicenseCodesService {
-  constructor(
-    private readonly paymentService: PaymentService,
-    private readonly usersService: UsersService,
-    private readonly storageService: StorageService,
-    private readonly licenseCodesRepository: LicenseCodesRepository,
-    private readonly tiersService: TiersService,
-  ) {}
+  private readonly paymentService: PaymentService;
+  private readonly usersService: UsersService;
+  private readonly storageService: StorageService;
+  private readonly licenseCodesRepository: LicenseCodesRepository;
+  private readonly tiersService: TiersService;
+
+  constructor({
+    paymentService,
+    usersService,
+    storageService,
+    licenseCodesRepository,
+    tiersService,
+  }: LicenseCodesServiceDeps) {
+    this.paymentService = paymentService;
+    this.usersService = usersService;
+    this.storageService = storageService;
+    this.licenseCodesRepository = licenseCodesRepository;
+    this.tiersService = tiersService;
+  }
 
   async isLicenseCodeAvailable(code: LicenseCode['code'], provider: LicenseCode['provider']): Promise<boolean> {
     const licenseCode = await this.licenseCodesRepository.findOne(code, provider);
@@ -64,6 +84,7 @@ export class LicenseCodesService {
     },
     code: LicenseCode['code'],
     provider: LicenseCode['provider'],
+    logger: FastifyBaseLogger,
   ): Promise<void> {
     const licenseCode = await this.licenseCodesRepository.findOne(code, provider);
 
@@ -76,36 +97,42 @@ export class LicenseCodesService {
     }
 
     const maybeExistingUser = await this.usersService.findUserByUuid(user.uuid).catch(() => null);
-    let customerId: string;
+    let customer: Stripe.Customer;
 
     // 1. Create or get customer from Stripe
     if (!maybeExistingUser) {
-      customerId = (
-        await this.paymentService.createCustomer({
-          name: user.name || 'Internxt User',
-          email: user.email,
-        })
-      ).id;
+      customer = await this.paymentService.createCustomer({
+        name: user.name || 'Internxt User',
+        email: user.email,
+      });
     } else {
-      customerId = (await this.paymentService.getCustomer(maybeExistingUser.customerId)).id;
+      customer = (await this.paymentService.getCustomer(maybeExistingUser.customerId)) as Stripe.Customer;
     }
 
     // 2. Subscribe to the price referenced by the code
-    const productMetadata = await this.paymentService.subscribe(customerId, licenseCode.priceId);
+    const productMetadata = await this.paymentService.subscribe(customer.id, licenseCode.priceId);
 
-    // 3. Set the storage referenced by the code
-    await this.storageService.changeStorage(user.uuid, productMetadata.maxSpaceBytes);
-
-    // 4. Update user accordingly
+    // 3. Update user accordingly
     if (!maybeExistingUser) {
       await this.usersService.insertUser({
-        customerId,
+        customerId: customer.id,
         uuid: user.uuid,
         lifetime: !productMetadata.recurring,
       });
     } else {
       await this.usersService.updateUser(maybeExistingUser.customerId, { lifetime: !productMetadata.recurring });
     }
+
+    // 4. Apply features
+    const tierProduct = await this.getTierProduct(licenseCode);
+
+    await this.applyProductFeatures({
+      user,
+      customer,
+      logger,
+      maxSpaceBytes: productMetadata.maxSpaceBytes,
+      tierProduct,
+    });
 
     // 5. Mark code as redeemed
     await this.licenseCodesRepository.updateByCode(licenseCode.code, { redeemed: true });
@@ -131,13 +158,13 @@ export class LicenseCodesService {
     return tierProduct;
   }
 
-  private async applyProductFeatures(
-    user: { uuid: string; email: string },
-    customer: Stripe.Customer,
-    logger: FastifyBaseLogger,
-    maxSpaceBytes: number,
-    tierProduct: Tier | null,
-  ) {
+  private async applyProductFeatures({
+    user,
+    customer,
+    logger,
+    maxSpaceBytes,
+    tierProduct,
+  }: ApplyProductFeaturesProps): Promise<void> {
     try {
       // 3a. Apply tier to user and update/insert user-tier relationship
       if (tierProduct) {

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -43,8 +43,19 @@ export const getValidAuthToken = (
   workspaces?: {
     owners: string[];
   },
+  params?: Partial<{
+    email: string;
+    uuid: string;
+    name: string;
+    lastname: string;
+    username: string;
+    sharedWorkspace: boolean;
+    networkCredentials: {
+      user: string;
+    };
+  }>,
 ): string => {
-  return jwt.sign({ payload: { uuid: userUuid, workspaces } }, config.JWT_SECRET);
+  return jwt.sign({ payload: { uuid: userUuid, workspaces, ...params } }, config.JWT_SECRET);
 };
 
 export const getValidUserToken = (customerId: string): string => {

--- a/tests/src/services/licenseCodes.service.test.ts
+++ b/tests/src/services/licenseCodes.service.test.ts
@@ -74,13 +74,13 @@ describe('Tests for License Codes service', () => {
       storageService,
       config,
     );
-    licenseCodesService = new LicenseCodesService(
+    licenseCodesService = new LicenseCodesService({
       paymentService,
       usersService,
       storageService,
       licenseCodesRepository,
       tiersService,
-    );
+    });
   });
 
   describe('Check if license code is available', () => {
@@ -111,6 +111,10 @@ describe('Tests for License Codes service', () => {
         InvalidLicenseCodeError,
       );
     });
+  });
+
+  describe('Redeem codes', () => {
+    test('When the license code is valid, then it is marked as redeemed', async () => {});
   });
 
   describe('Get Tier product', () => {
@@ -188,7 +192,13 @@ describe('Tests for License Codes service', () => {
         const updateStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
 
         const applyProductFeatures = licenseCodesService['applyProductFeatures'].bind(licenseCodesService);
-        await applyProductFeatures(user, mockedCustomer, mockedLogger, maxSpaceBytes, null);
+        await applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes,
+          tierProduct: null,
+        });
 
         expect(updateStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, maxSpaceBytes);
       });
@@ -206,9 +216,15 @@ describe('Tests for License Codes service', () => {
 
         jest.spyOn(storageService, 'changeStorage').mockRejectedValue(unexpectedError);
         const applyProductFeatures = licenseCodesService['applyProductFeatures'].bind(licenseCodesService);
-        await expect(applyProductFeatures(user, mockedCustomer, mockedLogger, maxSpaceBytes, null)).rejects.toThrow(
-          unexpectedError,
-        );
+        await expect(
+          applyProductFeatures({
+            user,
+            customer: mockedCustomer,
+            logger: mockedLogger,
+            maxSpaceBytes,
+            tierProduct: null,
+          }),
+        ).rejects.toThrow(unexpectedError);
       });
     });
 
@@ -232,7 +248,13 @@ describe('Tests for License Codes service', () => {
         jest.spyOn(tiersService, 'insertTierToUser').mockResolvedValue();
 
         const applyProductFeatures = licenseCodesService['applyProductFeatures'].bind(licenseCodesService);
-        await applyProductFeatures(user, mockedCustomer, mockedLogger, 100, mockedTier);
+        await applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes: 100,
+          tierProduct: mockedTier,
+        });
 
         expect(applyTierSpy).toHaveBeenCalledWith(user, mockedCustomer, 1, mockedTier.id, mockedLogger);
       });
@@ -266,7 +288,13 @@ describe('Tests for License Codes service', () => {
         const insertTierToUserSpy = jest.spyOn(tiersService, 'insertTierToUser').mockResolvedValue();
 
         const applyProductFeatures = licenseCodesService['applyProductFeatures'].bind(licenseCodesService);
-        await applyProductFeatures(user, mockedCustomer, mockedLogger, 100, mockedTier);
+        await applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes: 100,
+          tierProduct: mockedTier,
+        });
 
         expect(insertTierToUserSpy).toHaveBeenCalledWith(mockedUser.id, mockedTier.id);
       });
@@ -292,7 +320,13 @@ describe('Tests for License Codes service', () => {
         const updateTierToUserSpy = jest.spyOn(tiersService, 'updateTierToUser').mockResolvedValue();
 
         const applyProductFeatures = licenseCodesService['applyProductFeatures'].bind(licenseCodesService);
-        await applyProductFeatures(user, mockedCustomer, mockedLogger, 100, mockedTier);
+        await applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes: 100,
+          tierProduct: mockedTier,
+        });
 
         expect(insertTierToUserSpy).not.toHaveBeenCalled();
         expect(updateTierToUserSpy).toHaveBeenCalledWith(mockedUser.id, mockedUserTier.id, mockedTier.id);
@@ -313,7 +347,13 @@ describe('Tests for License Codes service', () => {
         jest.spyOn(tiersService, 'applyTier').mockRejectedValue(unexpectedError);
         const applyProductFeatures = licenseCodesService['applyProductFeatures'].bind(licenseCodesService);
         await expect(
-          applyProductFeatures(user, mockedCustomer, mockedLogger, maxSpaceBytes, mockedTier),
+          applyProductFeatures({
+            user,
+            customer: mockedCustomer,
+            logger: mockedLogger,
+            maxSpaceBytes,
+            tierProduct: mockedTier,
+          }),
         ).rejects.toThrow(unexpectedError);
       });
     });

--- a/tests/src/services/licenseCodes.service.test.ts
+++ b/tests/src/services/licenseCodes.service.test.ts
@@ -186,7 +186,13 @@ describe('Tests for License Codes service', () => {
 
         jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as Stripe.Response<Stripe.Product>);
         const updateStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
-        await licenseCodesService.applyProductFeatures(user, mockedCustomer, mockedLogger, maxSpaceBytes, null);
+        await licenseCodesService.applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes,
+          tierProduct: null,
+        });
 
         expect(updateStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, maxSpaceBytes);
       });
@@ -204,7 +210,13 @@ describe('Tests for License Codes service', () => {
 
         jest.spyOn(storageService, 'changeStorage').mockRejectedValue(unexpectedError);
         await expect(
-          licenseCodesService.applyProductFeatures(user, mockedCustomer, mockedLogger, maxSpaceBytes, null),
+          licenseCodesService.applyProductFeatures({
+            user,
+            customer: mockedCustomer,
+            logger: mockedLogger,
+            maxSpaceBytes,
+            tierProduct: null,
+          }),
         ).rejects.toThrow(unexpectedError);
       });
     });
@@ -228,14 +240,19 @@ describe('Tests for License Codes service', () => {
         jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([]);
         jest.spyOn(tiersService, 'insertTierToUser').mockResolvedValue();
 
-        await licenseCodesService.applyProductFeatures(user, mockedCustomer, mockedLogger, 100, mockedTier);
+        await licenseCodesService.applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes: 100,
+          tierProduct: mockedTier,
+        });
 
         expect(applyTierSpy).toHaveBeenCalledWith(user, mockedCustomer, 1, mockedTier.id, mockedLogger);
       });
 
       test('When the user does not have any tier, then the tier-user relationship is inserted into the collection after applying the features', async () => {
         const mockedProduct = getProduct({});
-        const mockedLicenseCode = getLicenseCode();
         const mockedCustomer = getCustomer();
         const mockedLogger = getLogger();
         const mockedUser = getUser();
@@ -261,7 +278,13 @@ describe('Tests for License Codes service', () => {
         jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([mockedUserTier]);
         const insertTierToUserSpy = jest.spyOn(tiersService, 'insertTierToUser').mockResolvedValue();
 
-        await licenseCodesService.applyProductFeatures(user, mockedCustomer, mockedLogger, 100, mockedTier);
+        await licenseCodesService.applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes: 100,
+          tierProduct: mockedTier,
+        });
 
         expect(insertTierToUserSpy).toHaveBeenCalledWith(mockedUser.id, mockedTier.id);
       });
@@ -277,6 +300,7 @@ describe('Tests for License Codes service', () => {
         };
         const mockedUserTier = newTier();
         const mockedTier = newTier();
+        const maxSpaceBytes = 100;
 
         jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as Stripe.Response<Stripe.Product>);
         jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
@@ -286,7 +310,13 @@ describe('Tests for License Codes service', () => {
         const insertTierToUserSpy = jest.spyOn(tiersService, 'insertTierToUser');
         const updateTierToUserSpy = jest.spyOn(tiersService, 'updateTierToUser').mockResolvedValue();
 
-        await licenseCodesService.applyProductFeatures(user, mockedCustomer, mockedLogger, 100, mockedTier);
+        await licenseCodesService.applyProductFeatures({
+          user,
+          customer: mockedCustomer,
+          logger: mockedLogger,
+          maxSpaceBytes,
+          tierProduct: mockedTier,
+        });
 
         expect(insertTierToUserSpy).not.toHaveBeenCalled();
         expect(updateTierToUserSpy).toHaveBeenCalledWith(mockedUser.id, mockedUserTier.id, mockedTier.id);
@@ -306,7 +336,13 @@ describe('Tests for License Codes service', () => {
 
         jest.spyOn(tiersService, 'applyTier').mockRejectedValue(unexpectedError);
         await expect(
-          licenseCodesService.applyProductFeatures(user, mockedCustomer, mockedLogger, maxSpaceBytes, mockedTier),
+          licenseCodesService.applyProductFeatures({
+            user,
+            customer: mockedCustomer,
+            logger: mockedLogger,
+            maxSpaceBytes,
+            tierProduct: mockedTier,
+          }),
         ).rejects.toThrow(unexpectedError);
       });
     });


### PR DESCRIPTION
This PR applies the tier to a user if the price ID of the redeemed code matches any product associated with a tier. When a code is redeemed, the product's price ID is checked against the price IDs of all tiered products. If a match is found, the corresponding tier is applied. If not, we just update the storage.