### PR TITLE
[_]: fix/pass productId instead of the id

### DIFF
--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -166,7 +166,7 @@ export class LicenseCodesService {
   }: ApplyProductFeaturesProps): Promise<void> {
     try {
       if (tierProduct) {
-        await this.tiersService.applyTier(user, customer, 1, tierProduct.id, logger);
+        await this.tiersService.applyTier(user, customer, 1, tierProduct.productId, logger);
 
         const userId = (await this.usersService.findUserByUuid(user.uuid)).id;
         const existingTiersForUser = await this.tiersService.getTiersProductsByUserId(userId);

--- a/tests/src/services/licenseCodes.service.test.ts
+++ b/tests/src/services/licenseCodes.service.test.ts
@@ -415,7 +415,7 @@ describe('Tests for License Codes service', () => {
           tierProduct: mockedTier,
         });
 
-        expect(applyTierSpy).toHaveBeenCalledWith(user, mockedCustomer, 1, mockedTier.id, mockedLogger);
+        expect(applyTierSpy).toHaveBeenCalledWith(user, mockedCustomer, 1, mockedTier.productId, mockedLogger);
       });
 
       test('When the user does not have any tier, then the tier-user relationship is inserted into the collection after applying the features', async () => {


### PR DESCRIPTION
This PR fixes the property we pass to apply the tier. We need to pass the product ID instead of the local document ID from the tier we want to apply.