### PR TITLE
[_]: fix/handle tier not found error

### DIFF
--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -169,7 +169,13 @@ export class LicenseCodesService {
         await this.tiersService.applyTier(user, customer, 1, tierProduct.productId, logger);
 
         const userId = (await this.usersService.findUserByUuid(user.uuid)).id;
-        const existingTiersForUser = await this.tiersService.getTiersProductsByUserId(userId);
+        const existingTiersForUser = await this.tiersService.getTiersProductsByUserId(userId).catch((error) => {
+          if (error instanceof TierNotFoundError) {
+            return [];
+          }
+
+          throw error;
+        });
         const existingIndividualTier = existingTiersForUser.find(
           (tierProduct) => !tierProduct.featuresPerService[Service.Drive].workspaces.enabled,
         );

--- a/tests/src/services/licenseCodes.service.test.ts
+++ b/tests/src/services/licenseCodes.service.test.ts
@@ -392,6 +392,7 @@ describe('Tests for License Codes service', () => {
 
     describe('Redeemed code with tier', () => {
       test('When the user redeems a valid code that match with any tier, then the tier is applied', async () => {
+        const tierNotFoundError = new TierNotFoundError('Tier not found');
         const mockedCustomer = getCustomer();
         const mockedLogger = getLogger();
         const mockedUser = getUser();
@@ -404,7 +405,7 @@ describe('Tests for License Codes service', () => {
         jest.spyOn(usersService, 'findUserByUuid').mockResolvedValue(mockedUser);
         const applyTierSpy = jest.spyOn(tiersService, 'applyTier').mockResolvedValue();
         jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedTier);
-        jest.spyOn(tiersService, 'getTiersProductsByUserId').mockResolvedValue([]);
+        jest.spyOn(tiersService, 'getTiersProductsByUserId').mockRejectedValue(tierNotFoundError);
         jest.spyOn(tiersService, 'insertTierToUser').mockResolvedValue();
 
         await licenseCodesService.applyProductFeatures({


### PR DESCRIPTION
This PR handles the error when the we try to get the user tiers and he does not have anyone assigned. If that happens, we just return an empty array so the find function will return null, so we will insert the user tier relationship.