### PR TITLE
[_]: feat/return available crypto currencies

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -345,5 +345,22 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
         });
       },
     );
+
+    fastify.get(
+      '/currencies/crypto',
+      {
+        config: {
+          skipAuth: true,
+          rateLimit: {
+            max: 5,
+            timeWindow: '1 minute',
+          },
+        },
+      },
+      async (req, res) => {
+        const cryptoCurrencies = await paymentsService.getCryptoCurrencies();
+        return res.status(200).send(cryptoCurrencies);
+      },
+    );
   };
 }

--- a/tests/src/controller/checkout.controller.test.ts
+++ b/tests/src/controller/checkout.controller.test.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import {
   getCreatedSubscription,
   getCreateSubscriptionResponse,
+  getCryptoCurrency,
   getCustomer,
   getInvoice,
   getTaxes,
@@ -16,6 +17,7 @@ import { UserNotFoundError, UsersService } from '../../../src/services/users.ser
 import { PaymentIntent, PaymentService } from '../../../src/services/payment.service';
 import { fetchUserStorage } from '../../../src/utils/fetchUserStorage';
 import Stripe from 'stripe';
+import { AllowedCurrencies } from '../../../src/services/bit2me.service';
 
 jest.mock('../../../src/utils/fetchUserStorage');
 
@@ -632,6 +634,28 @@ describe('Checkout controller', () => {
           },
         });
       });
+    });
+  });
+
+  describe('Get crypto currencies', () => {
+    test('When the currencies are requested, then the available currencies are returned', async () => {
+      const mockedCurrencies = [
+        getCryptoCurrency(),
+        getCryptoCurrency({
+          name: AllowedCurrencies['Ethereum'],
+        }),
+      ];
+      jest.spyOn(PaymentService.prototype, 'getCryptoCurrencies').mockResolvedValue(mockedCurrencies);
+
+      const response = await app.inject({
+        path: '/checkout/currencies/crypto',
+        method: 'GET',
+      });
+
+      const responseBody = response.json();
+
+      expect(response.statusCode).toBe(200);
+      expect(responseBody).toStrictEqual(mockedCurrencies);
     });
   });
 });


### PR DESCRIPTION
This PR introduces a new API endpoint to retrieve the list of available cryptocurrencies. This list will be used on the client side, specifically in our custom checkout flow, to display supported crypto payment options.