### PR TITLE
[PB-4735]: chore/bump stripe version to v16.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^6.10.0",
-    "stripe": "^15.10.0",
+    "stripe": "=16.12.0",
     "uuid": "^11.1.0"
   }
 }

--- a/src/cli/load-license-codes.ts
+++ b/src/cli/load-license-codes.ts
@@ -61,7 +61,7 @@ function loadFromExcel(): LicenseCode[] {
 async function main() {
   const mongoClient = await new MongoClient(envVariablesConfig.MONGO_URI).connect();
   try {
-    const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' });
+    const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
     const usersRepository: UsersRepository = new MongoDBUsersRepository(mongoClient);
     const storageService = new StorageService(envVariablesConfig, axios);
     const licenseCodesRepository: LicenseCodesRepository = new MongoDBLicenseCodesRepository(mongoClient);

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ const start = async (mongoTestClient?: MongoClient): Promise<FastifyInstance> =>
   const tiersRepository: TiersRepository = new MongoDBTiersRepository(mongoClient);
   const usersTiersRepository: UsersTiersRepository = new MongoDBUsersTiersRepository(mongoClient);
 
-  const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' });
+  const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
   const bit2MeService = new Bit2MeService(envVariablesConfig, axios);
   const paymentService = new PaymentService(stripe, productsRepository, bit2MeService);
   const storageService = new StorageService(envVariablesConfig, axios);

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -322,6 +322,7 @@ export const getPrice = (params?: Partial<Stripe.Price>): Stripe.Price => {
     nickname: null,
     product: 'prod_NZKdYqrwEYx6iK',
     recurring: {
+      meter: null,
       aggregate_usage: null,
       interval: 'month',
       interval_count: 1,
@@ -521,6 +522,7 @@ export const getCreatedSubscription = (
           metadata: {},
           discounts: null as any,
           plan: {
+            meter: null,
             id: `price_${randomDataGenerator.string({ length: 20 })}`,
             object: 'plan',
             active: true,
@@ -574,6 +576,7 @@ export const getCreatedSubscription = (
             nickname: null,
             product: `prod_${randomDataGenerator.string({ length: 12 })}`,
             recurring: {
+              meter: null,
               aggregate_usage: null,
               interval: 'month',
               interval_count: 1,
@@ -1267,6 +1270,7 @@ export function getCharge(params?: Partial<Stripe.Charge>): Stripe.Charge {
     payment_method: `card_${randomDataGenerator.string({ length: 10 })}`,
     payment_method_details: {
       card: {
+        authorization_code: null,
         amount_authorized: 0,
         brand: 'visa',
         checks: {

--- a/tests/src/helpers/services-factory.ts
+++ b/tests/src/helpers/services-factory.ts
@@ -69,7 +69,7 @@ const createRepositories = (): TestRepositories => ({
 export const createTestServices = (overrides: TestServiceOverrides = {}): TestServices & TestRepositories => {
   const repositories = createRepositories();
 
-  const stripe = overrides.stripe ?? new Stripe(config.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' });
+  const stripe = overrides.stripe ?? new Stripe(config.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
   const bit2MeService = new Bit2MeService(config, axios);
   const paymentService = new PaymentService(stripe, repositories.productsRepository, bit2MeService);
   const storageService = new StorageService(config, axios);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,10 +3872,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^15.10.0:
-  version "15.12.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-15.12.0.tgz#a30c242861f9c97dd31d3078fb0673d9bd10efe2"
-  integrity sha512-slTbYS1WhRJXVB8YXU8fgHizkUrM9KJyrw4Dd8pLEwzKHYyQTIE46EePC2MVbSDZdE24o1GdNtzmJV4PrPpmJA==
+stripe@=16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-16.12.0.tgz#75e3d8f0f35bea14885cb3605a41d6afc182aa66"
+  integrity sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==
   dependencies:
     "@types/node" ">=8.1.0"
     qs "^6.11.0"


### PR DESCRIPTION
This PR updates the Stripe SDK from v15.10.0 to  v16.12.0. We need to update the Stripe SDK to v18.X in order to use `Klarna` as an allowed payment method when creating invoices.