### PR TITLE
[PB-4735]: chore/bump stripe version to v17.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^6.10.0",
-    "stripe": "=16.12.0",
+    "stripe": "=17.7.0",
     "uuid": "^11.1.0"
   }
 }

--- a/src/cli/load-license-codes.ts
+++ b/src/cli/load-license-codes.ts
@@ -61,7 +61,7 @@ function loadFromExcel(): LicenseCode[] {
 async function main() {
   const mongoClient = await new MongoClient(envVariablesConfig.MONGO_URI).connect();
   try {
-    const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
+    const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2025-02-24.acacia' });
     const usersRepository: UsersRepository = new MongoDBUsersRepository(mongoClient);
     const storageService = new StorageService(envVariablesConfig, axios);
     const licenseCodesRepository: LicenseCodesRepository = new MongoDBLicenseCodesRepository(mongoClient);

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ const start = async (mongoTestClient?: MongoClient): Promise<FastifyInstance> =>
   const tiersRepository: TiersRepository = new MongoDBTiersRepository(mongoClient);
   const usersTiersRepository: UsersTiersRepository = new MongoDBUsersTiersRepository(mongoClient);
 
-  const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
+  const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2025-02-24.acacia' });
   const bit2MeService = new Bit2MeService(envVariablesConfig, axios);
   const paymentService = new PaymentService(stripe, productsRepository, bit2MeService);
   const storageService = new StorageService(envVariablesConfig, axios);

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -228,6 +228,11 @@ export const getTaxes = (params?: Partial<Stripe.Tax.Calculation>): Stripe.Tax.C
           percentage_decimal: '21',
           state: 'ES',
           tax_type: 'vat',
+          flat_amount: {
+            amount: 0,
+            currency: 'EUR',
+          },
+          rate_type: 'flat_amount',
         },
         taxability_reason: 'standard_rated',
         taxable_amount: 11988,
@@ -381,6 +386,7 @@ export const getCreatedSubscription = (
     automatic_tax: {
       enabled: false,
       liability: null,
+      disabled_reason: null,
     },
     billing_cycle_anchor: randomDataGenerator.natural({ length: 10 }),
     billing_thresholds: null,
@@ -427,6 +433,7 @@ export const getCreatedSubscription = (
         routing_number: '110000000',
         swift_code: 'TSTEZ122',
       },
+      allow_redisplay: null,
       amount: null,
       client_secret: 'src_client_secret_ZaOIRUD8a9uGmQobLxGvqKSr',
       created: 1683144457,
@@ -1258,6 +1265,9 @@ export function getCharge(params?: Partial<Stripe.Charge>): Stripe.Charge {
     metadata: {},
     on_behalf_of: null,
     outcome: {
+      advice_code: null,
+      network_advice_code: null,
+      network_decline_code: null,
       network_status: 'approved_by_network',
       reason: null,
       risk_level: 'normal',
@@ -1270,6 +1280,8 @@ export function getCharge(params?: Partial<Stripe.Charge>): Stripe.Charge {
     payment_method: `card_${randomDataGenerator.string({ length: 10 })}`,
     payment_method_details: {
       card: {
+        network_transaction_id: null,
+        regulated_status: null,
         authorization_code: null,
         amount_authorized: 0,
         brand: 'visa',
@@ -1318,7 +1330,9 @@ export function getDispute(params?: Partial<Stripe.Dispute>): Stripe.Dispute {
     charge: `ch_${randomDataGenerator.string({ length: 16 })}`,
     created: 1680651737,
     currency: 'usd',
+    enhanced_eligibility_types: [],
     evidence: {
+      enhanced_evidence: {},
       access_activity_log: null,
       billing_address: null,
       cancellation_policy: null,
@@ -1348,6 +1362,7 @@ export function getDispute(params?: Partial<Stripe.Dispute>): Stripe.Dispute {
       uncategorized_text: null,
     },
     evidence_details: {
+      enhanced_eligibility: {},
       due_by: 1682294399,
       has_evidence: false,
       past_due: false,

--- a/tests/src/helpers/services-factory.ts
+++ b/tests/src/helpers/services-factory.ts
@@ -69,7 +69,7 @@ const createRepositories = (): TestRepositories => ({
 export const createTestServices = (overrides: TestServiceOverrides = {}): TestServices & TestRepositories => {
   const repositories = createRepositories();
 
-  const stripe = overrides.stripe ?? new Stripe(config.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
+  const stripe = overrides.stripe ?? new Stripe(config.STRIPE_SECRET_KEY, { apiVersion: '2025-02-24.acacia' });
   const bit2MeService = new Bit2MeService(config, axios);
   const paymentService = new PaymentService(stripe, repositories.productsRepository, bit2MeService);
   const storageService = new StorageService(config, axios);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,10 +3872,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@=16.12.0:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-16.12.0.tgz#75e3d8f0f35bea14885cb3605a41d6afc182aa66"
-  integrity sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==
+stripe@=17.7.0:
+  version "17.7.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-17.7.0.tgz#7816be2559e6f58bf4c005758fe20be78cdbf995"
+  integrity sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==
   dependencies:
     "@types/node" ">=8.1.0"
     qs "^6.11.0"


### PR DESCRIPTION
This PR updates the Stripe SDK from v16.12.0 to v17.7.0. We need to update the Stripe SDK to v18.X in order to use Klarna as an allowed payment method when creating invoices.