### PR TITLE
[PB-3649]: feat/retrieve the pre created invoice instead of creating a preview

### DIFF
--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -449,30 +449,12 @@ export class PaymentService {
     if (isLifetime && isCryptoCurrency(currency)) {
       const normalizedCurrencyForBit2Me = normalizeForBit2Me(currency);
 
-      const upcomingInvoice = await this.provider.invoices.retrieveUpcoming({
-        customer: customerId,
-        subscription_items: undefined,
-        automatic_tax: {
-          enabled: true,
-        },
-        invoice_items: [
-          {
-            price: priceId,
-            quantity: 1,
-            discounts: [
-              {
-                coupon: couponId,
-              },
-            ],
-          },
-        ],
-        currency: normalizedCurrencyForStripe,
-      });
+      const upcomingInvoice = await this.provider.invoices.retrieve(invoice.id);
 
-      const priceAmount = upcomingInvoice.amount_remaining / 100;
+      const priceAmount = upcomingInvoice.total / 100;
 
       Logger.info(
-        `Crypto payment amount: ${priceAmount} ${normalizedCurrencyForBit2Me}. Raw invoice: ${upcomingInvoice.amount_remaining}`,
+        `Crypto payment amount: ${priceAmount} ${normalizedCurrencyForBit2Me}. Raw invoice: ${upcomingInvoice.total}`,
       );
 
       const cryptoInvoice = await this.bit2MeService.createCryptoInvoice({

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -258,7 +258,7 @@ describe('Payments Service tests', () => {
 
         jest.spyOn(stripe.invoices, 'update').mockImplementation();
         jest
-          .spyOn(stripe.invoices, 'retrieveUpcoming')
+          .spyOn(stripe.invoices, 'retrieve')
           .mockResolvedValue(mockedInvoice as unknown as Stripe.Response<Stripe.Invoice>);
         jest
           .spyOn(stripe.invoices, 'finalizeInvoice')


### PR DESCRIPTION
This PR improves the total we pass to the crypto invoice by retrieving the total of the invoice to be paid instead of creating a preview of an upcoming invoice.