### PR TITLE
[_]:feature/handle paid_after_expired status for crypto invoices

### DIFF
--- a/src/webhooks/providers/bit2me/index.ts
+++ b/src/webhooks/providers/bit2me/index.ts
@@ -87,7 +87,8 @@ export default function ({
         );
       }
 
-      if (status !== 'paid') {
+      const isPaid = status === 'paid_after_expired' || status === 'paid';
+      if (!isPaid) {
         Logger.info(`Invoice ${stripeInvoiceId} for customer ${customerId} is not paid. Status: ${status}`);
         return rep.status(200).send();
       }


### PR DESCRIPTION
This PR handles the status `paid_after_expired` for crypto invoices because the invoice is paid after the expiration date in some cases or, when the provider sends us an event marking the invoice as paid, they will send us this one instead of `paid`.