### PR TITLE
[_]: fix/return the available products for bit2me invoices

### DIFF
--- a/src/services/tiers.service.ts
+++ b/src/services/tiers.service.ts
@@ -139,8 +139,11 @@ export class TiersService {
       for (const invoice of paidInvoices) {
         const lineItem = invoice.lines?.data[0];
         const product = lineItem?.price?.product as string | undefined;
+        const invoiceMetadata = invoice.metadata;
+        const invoiceMetadataProvider = invoiceMetadata?.provider;
+        const isBit2MeProvider = invoiceMetadataProvider === 'bit2me';
 
-        if (invoice.paid_out_of_band) {
+        if (invoice.paid_out_of_band && !isBit2MeProvider) {
           isLifetimePaidOutOfBand = true;
           break;
         }

--- a/src/services/tiers.service.ts
+++ b/src/services/tiers.service.ts
@@ -142,8 +142,9 @@ export class TiersService {
         const invoiceMetadata = invoice.metadata;
         const invoiceMetadataProvider = invoiceMetadata?.provider;
         const isBit2MeProvider = invoiceMetadataProvider === 'bit2me';
+        const isExternalPayment = invoice.paid_out_of_band && !isBit2MeProvider;
 
-        if (invoice.paid_out_of_band && !isBit2MeProvider) {
+        if (isExternalPayment) {
           isLifetimePaidOutOfBand = true;
           break;
         }


### PR DESCRIPTION
This PR adds a condition for invoices paid outside the system, so that users who have paid an invoice using cryptocurrencies (bit2me) can use the antivirus and backup services.