### PR TITLE
[_]: fix/insert user in DB after creating customer

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -91,6 +91,12 @@ export default function (usersService: UsersService, paymentsService: PaymentSer
               postal_code: postalCode,
             },
           });
+          await usersService.insertUser({
+            customerId: id,
+            uuid: userUuid,
+            lifetime: false,
+          });
+
           customerId = id;
         }
 

--- a/tests/src/controller/checkout.controller.test.ts
+++ b/tests/src/controller/checkout.controller.test.ts
@@ -79,9 +79,10 @@ describe('Checkout controller', () => {
       });
     });
 
-    it('When the user does not exists in Users collection, then the customer is created and the customer Id is returned', async () => {
+    test('When the user does not exists in Users collection, then the customer is created, added in our DB and the customer Id is returned', async () => {
       const mockedUser = getUser();
       const mockedCustomer = getCustomer({
+        id: mockedUser.customerId,
         address: {
           country: 'ES',
           postal_code: '08001',
@@ -93,9 +94,15 @@ describe('Checkout controller', () => {
       });
       const userAuthToken = getValidAuthToken(mockedUser.uuid);
       const userToken = getValidUserToken({ customerId: mockedCustomer.id });
+      const insertUserPayload = {
+        customerId: mockedCustomer.id,
+        uuid: mockedUser.uuid,
+        lifetime: false,
+      };
 
       jest.spyOn(UsersService.prototype, 'findUserByUuid').mockRejectedValue(UserNotFoundError);
       jest.spyOn(PaymentService.prototype, 'createCustomer').mockResolvedValue(mockedCustomer);
+      const insertUserSpy = jest.spyOn(UsersService.prototype, 'insertUser').mockResolvedValue();
 
       const response = await app.inject({
         path: '/checkout/customer',
@@ -116,6 +123,7 @@ describe('Checkout controller', () => {
         customerId: mockedCustomer.id,
         token: userToken,
       });
+      expect(insertUserSpy).toHaveBeenCalledWith(insertUserPayload);
     });
 
     it('When the user provides country and Vat Id, then they are attached to the user correctly', async () => {


### PR DESCRIPTION
This PR adds the insertion of the user into the database immediately after the customer is created. This change prevents the creation of multiple customers in case a payment fails, since previously the system could not verify whether the user already had a customer until the purchase was completed, at which point the user was added to the database.

This PR depends on the following:
- https://github.com/internxt/payments-server/pull/294