### PR TITLE
[_]: fix/payment methods for invoices

### DIFF
--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -424,7 +424,8 @@ export class PaymentService {
   }): Promise<PaymentIntent> {
     let couponId: string | undefined = undefined;
     const normalizedCurrencyForStripe = normalizeForStripe(currency);
-    const paymentMethodTypes = ['card', 'paypal', 'klarna'];
+    const paymentMethodTypes =
+      normalizedCurrencyForStripe === 'eur' ? ['card', 'paypal', 'klarna'] : ['card', 'paypal'];
     const stripeNewVersion = getStripeNewVersion();
 
     const invoice = await stripeNewVersion.invoices.create({


### PR DESCRIPTION
This PR removes the klarna payment method for USD currencies because this currency is not allowed to Klarna. More info [here](https://docs.stripe.com/payments/klarna#cross-border-payments).