### PR TITLE
[PB-5033]: feat/notify-failed-payment-on-invoice-payment-failed

### DIFF
--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -298,6 +298,23 @@ export class UsersService {
 
     return this.axios.delete(`${this.config.VPN_URL}/gateway/users/${userUuid}/tiers/${featureId}`, requestConfig);
   }
+
+  async notifyFailedPayment(userUuid: string): Promise<void> {
+    const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
+
+    const requestConfig: AxiosRequestConfig = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt}`,
+      },
+    };
+    
+    await this.axios.post(
+      `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/users/failed-payment`,
+      { userId: userUuid },
+      requestConfig,
+    );
+  }
 }
 
 export class UserNotFoundError extends HttpError {

--- a/src/webhooks/handleInvoicePaymentFailed.ts
+++ b/src/webhooks/handleInvoicePaymentFailed.ts
@@ -57,7 +57,8 @@ export default async function handleInvoicePaymentFailed(
       logger.warn(`User not found for customer ${customer.id}. Skipping failed payment notification.`);
     }
   } catch (error) {
-    logger.error(`Failed to send payment notification for customer ${customer.id}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Failed to send payment notification for customer ${customer.id}. Error: ${errorMessage}`);
   }
 
   const relevantLineItem = await findObjectStorageLineItem(invoice, paymentService);

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -54,7 +54,7 @@ export default function (
 
       switch (event.type) {
         case 'invoice.payment_failed':
-          await handleInvoicePaymentFailed(event.data.object, objectStorageService, paymentService, fastify.log);
+          await handleInvoicePaymentFailed(event.data.object, objectStorageService, paymentService, usersService, fastify.log);
           break;
 
         case 'payment_intent.amount_capturable_updated':

--- a/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
+++ b/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
@@ -14,24 +14,24 @@ beforeEach(() => {
 
 describe('Handle Invoice Payment Failed', () => {
   describe('When processing valid payment failure', () => {
-    it('When payment fails for object storage invoice, then should notify gateway service and suspend account', async () => {
+    it('When payment fails for object storage invoice, then should only suspend account without Drive notification', async () => {
     const customerId = 'cus_test123';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
     const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
-    const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
 
     const getCustomerSpy = jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
     const getProductSpy = jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
-    const findUserByCustomerIDSpy = jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
-    const notifyFailedPaymentSpy = jest.spyOn(usersService, 'notifyFailedPayment').mockResolvedValue();
+    const findUserByCustomerIDSpy = jest.spyOn(usersService, 'findUserByCustomerID');
+    const notifyFailedPaymentSpy = jest.spyOn(usersService, 'notifyFailedPayment');
     const suspendAccountSpy = jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
 
     await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
 
     expect(getCustomerSpy).toHaveBeenCalledWith(customerId);
-    expect(findUserByCustomerIDSpy).toHaveBeenCalledWith(customerId);
-    expect(notifyFailedPaymentSpy).toHaveBeenCalledWith('test-uuid-123');
+    expect(findUserByCustomerIDSpy).not.toHaveBeenCalled();
+    expect(notifyFailedPaymentSpy).not.toHaveBeenCalled();
+    expect(suspendAccountSpy).toHaveBeenCalledWith({ customerId });
     });
   });
 
@@ -73,7 +73,7 @@ describe('Handle Invoice Payment Failed', () => {
     );
   });
 
-  it('When error is not an Error instance, then should log stringified error', async () => {
+  it('When an unexpected error occurs while notifying payment failure, then it is logged and processing continues', async () => {
     const customerId = 'cus_test123';
     const nonErrorObject = { code: 500, message: 'Server error' };
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
@@ -94,17 +94,16 @@ describe('Handle Invoice Payment Failed', () => {
     );
   });
 
-  it('When findUserByCustomerID throws error, then should log error and continue', async () => {
+  it('When an error happens while looking for the user, then it is logged and goes to the next step', async () => {
     const customerId = 'cus_test123';
     const errorMessage = 'Database connection failed';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
-    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'drive-product' } } });
 
     jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
     jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
     jest.spyOn(usersService, 'findUserByCustomerID').mockRejectedValue(new Error(errorMessage));
-    jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
     const loggerErrorSpy = jest.spyOn(logger, 'error');
 
     await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
@@ -122,7 +121,7 @@ describe('Handle Invoice Payment Failed', () => {
     ).rejects.toThrow('No customer found for this payment');
   });
 
-  it('When user is not found in payments database, then should skip notification and suspend account', async () => {
+  it('When object storage payment fails, then should skip notification and suspend account', async () => {
     const customerId = 'cus_test123';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
@@ -130,12 +129,13 @@ describe('Handle Invoice Payment Failed', () => {
 
     jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
     jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
-    jest.spyOn(usersService, 'findUserByCustomerID').mockRejectedValue(new Error('User not found'));
+    const findUserByCustomerIDSpy = jest.spyOn(usersService, 'findUserByCustomerID');
     const notifyFailedPaymentSpy = jest.spyOn(usersService, 'notifyFailedPayment');
     const suspendAccountSpy = jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
 
     await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
 
+    expect(findUserByCustomerIDSpy).not.toHaveBeenCalled();
     expect(notifyFailedPaymentSpy).not.toHaveBeenCalled();
     expect(suspendAccountSpy).toHaveBeenCalledWith({ customerId });
   });
@@ -144,20 +144,19 @@ describe('Handle Invoice Payment Failed', () => {
     const customerId = 'cus_test123';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
-    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'drive-product' } } });
     const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
 
     jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
     jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
     jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
     jest.spyOn(usersService, 'notifyFailedPayment').mockResolvedValue();
-    jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
     const loggerInfoSpy = jest.spyOn(logger, 'info');
 
     await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
 
     expect(loggerInfoSpy).toHaveBeenCalledWith(
-      `Failed payment notification sent for customer ${customerId} (user UUID: ${mockedUser.uuid})`
+      `Drive payment failure notification sent for customer ${customerId} (user UUID: ${mockedUser.uuid})`
     );
   });
 
@@ -165,12 +164,11 @@ describe('Handle Invoice Payment Failed', () => {
     const customerId = 'cus_test123';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
-    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'drive-product' } } });
 
     jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
     jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
     jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(null as any);
-    jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
     const loggerWarnSpy = jest.spyOn(logger, 'warn');
 
     await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);

--- a/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
+++ b/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
@@ -73,6 +73,47 @@ describe('Handle Invoice Payment Failed', () => {
     );
   });
 
+  it('When error is not an Error instance, then should log stringified error', async () => {
+    const customerId = 'cus_test123';
+    const nonErrorObject = { code: 500, message: 'Server error' };
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'non-object-storage' } } });
+    const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
+    jest.spyOn(usersService, 'notifyFailedPayment').mockRejectedValue(nonErrorObject);
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      `Failed to send payment notification for customer ${customerId}. Error: ${String(nonErrorObject)}`
+    );
+  });
+
+  it('When findUserByCustomerID throws error, then should log error and continue', async () => {
+    const customerId = 'cus_test123';
+    const errorMessage = 'Database connection failed';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockRejectedValue(new Error(errorMessage));
+    jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
+    const loggerErrorSpy = jest.spyOn(logger, 'error');
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      `Failed to send payment notification for customer ${customerId}. Error: ${errorMessage}`
+    );
+  });
+
   it('When customer is not found in invoice, then should throw error', async () => {
     const mockedInvoice = getInvoice({ customer: null });
 

--- a/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
+++ b/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
@@ -1,0 +1,60 @@
+import { FastifyBaseLogger } from 'fastify';
+import { getCustomer, getInvoice, getLogger, getProduct } from '../fixtures';
+import handleInvoicePaymentFailed from '../../../src/webhooks/handleInvoicePaymentFailed';
+import { createTestServices } from '../helpers/services-factory';
+
+const logger: jest.Mocked<FastifyBaseLogger> = getLogger();
+
+const { paymentService, usersService, objectStorageService } = createTestServices();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
+
+describe('Handle Invoice Payment Failed', () => {
+  it('Should notify gateway service when payment fails for any invoice', async () => {
+    const customerId = 'cus_test123';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+    const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
+
+    const getCustomerSpy = jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    const getProductSpy = jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    const findUserByCustomerIDSpy = jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
+    const notifyFailedPaymentSpy = jest.spyOn(usersService, 'notifyFailedPayment').mockResolvedValue();
+    const suspendAccountSpy = jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(getCustomerSpy).toHaveBeenCalledWith(customerId);
+    expect(findUserByCustomerIDSpy).toHaveBeenCalledWith(customerId);
+    expect(notifyFailedPaymentSpy).toHaveBeenCalledWith('test-uuid-123');
+  });
+
+  it('Should continue execution if gateway notification fails', async () => {
+    const customerId = 'cus_test123';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'non-object-storage' } } });
+    const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
+    jest.spyOn(usersService, 'notifyFailedPayment').mockRejectedValue(new Error('Gateway error'));
+
+    await expect(
+      handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger)
+    ).resolves.toBeUndefined();
+  });
+
+  it('Should throw error when customer is not found in invoice', async () => {
+    const mockedInvoice = getInvoice({ customer: null });
+
+    await expect(
+      handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger)
+    ).rejects.toThrow('No customer found for this payment');
+  });
+});

--- a/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
+++ b/tests/src/webhooks/handleInvoicePaymentFailed.test.ts
@@ -13,7 +13,8 @@ beforeEach(() => {
 });
 
 describe('Handle Invoice Payment Failed', () => {
-  it('Should notify gateway service when payment fails for any invoice', async () => {
+  describe('When processing valid payment failure', () => {
+    it('When payment fails for object storage invoice, then should notify gateway service and suspend account', async () => {
     const customerId = 'cus_test123';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
@@ -31,9 +32,10 @@ describe('Handle Invoice Payment Failed', () => {
     expect(getCustomerSpy).toHaveBeenCalledWith(customerId);
     expect(findUserByCustomerIDSpy).toHaveBeenCalledWith(customerId);
     expect(notifyFailedPaymentSpy).toHaveBeenCalledWith('test-uuid-123');
+    });
   });
 
-  it('Should continue execution if gateway notification fails', async () => {
+  it('When gateway notification fails, then should continue execution without throwing error', async () => {
     const customerId = 'cus_test123';
     const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
     const mockedInvoice = getInvoice({ customer: customerId });
@@ -50,11 +52,88 @@ describe('Handle Invoice Payment Failed', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('Should throw error when customer is not found in invoice', async () => {
+  it('When customer is not found in invoice, then should throw error', async () => {
     const mockedInvoice = getInvoice({ customer: null });
 
     await expect(
       handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger)
     ).rejects.toThrow('No customer found for this payment');
+  });
+
+  it('When user is not found in payments database, then should skip notification and suspend account', async () => {
+    const customerId = 'cus_test123';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockRejectedValue(new Error('User not found'));
+    const notifyFailedPaymentSpy = jest.spyOn(usersService, 'notifyFailedPayment');
+    const suspendAccountSpy = jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(notifyFailedPaymentSpy).not.toHaveBeenCalled();
+    expect(suspendAccountSpy).toHaveBeenCalledWith({ customerId });
+  });
+
+  it('When failed payment notification is sent successfully, then should log success message', async () => {
+    const customerId = 'cus_test123';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+    const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
+    jest.spyOn(usersService, 'notifyFailedPayment').mockResolvedValue();
+    jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
+    const loggerInfoSpy = jest.spyOn(logger, 'info');
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      `Failed payment notification sent for customer ${customerId} (user UUID: ${mockedUser.uuid})`
+    );
+  });
+
+  it('When user is not found for customer, then should log warning message', async () => {
+    const customerId = 'cus_test123';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'object-storage' } } });
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(null as any);
+    jest.spyOn(objectStorageService, 'suspendAccount').mockResolvedValue();
+    const loggerWarnSpy = jest.spyOn(logger, 'warn');
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      `User not found for customer ${customerId}. Skipping failed payment notification.`
+    );
+  });
+
+  it('When invoice has no object storage products, then should notify user but not suspend account', async () => {
+    const customerId = 'cus_test123';
+    const mockedCustomer = getCustomer({ id: customerId, email: 'test@internxt.com' });
+    const mockedInvoice = getInvoice({ customer: customerId });
+    const mockedProduct = getProduct({ params: { metadata: { type: 'regular-product' } } });
+    const mockedUser = { uuid: 'test-uuid-123', email: 'test@internxt.com' };
+
+    jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
+    jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
+    jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser as any);
+    const notifyFailedPaymentSpy = jest.spyOn(usersService, 'notifyFailedPayment');
+    const suspendAccountSpy = jest.spyOn(objectStorageService, 'suspendAccount');
+
+    await handleInvoicePaymentFailed(mockedInvoice as any, objectStorageService, paymentService, usersService, logger);
+
+    expect(notifyFailedPaymentSpy).toHaveBeenCalledWith('test-uuid-123');
+    expect(suspendAccountSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/src/webhooks/webhook.test.ts
+++ b/tests/src/webhooks/webhook.test.ts
@@ -5,6 +5,7 @@ import { getCustomer, getInvoice, getPaymentIntent } from '../fixtures';
 import handleFundsCaptured from '../../../src/webhooks/handleFundsCaptured';
 import { PaymentService } from '../../../src/services/payment.service';
 import { ObjectStorageService } from '../../../src/services/objectStorage.service';
+import { UsersService } from '../../../src/services/users.service';
 import handleInvoicePaymentFailed from '../../../src/webhooks/handleInvoicePaymentFailed';
 import { InvoiceCompletedHandler } from '../../../src/webhooks/events/invoices/InvoiceCompletedHandler';
 
@@ -91,7 +92,7 @@ describe('Webhook events', () => {
         event.data.object,
         expect.any(ObjectStorageService),
         expect.any(PaymentService),
-        expect.any(Object),
+        expect.any(UsersService),
         app.log,
       );
     });

--- a/tests/src/webhooks/webhook.test.ts
+++ b/tests/src/webhooks/webhook.test.ts
@@ -91,6 +91,7 @@ describe('Webhook events', () => {
         event.data.object,
         expect.any(ObjectStorageService),
         expect.any(PaymentService),
+        expect.any(Object),
         app.log,
       );
     });


### PR DESCRIPTION
This PR modifies the existing failed payment handler and adds a method to call an endpoint in gateway drive-server-wip to notify that this event has been triggered from the payment provider.

- Modified handleInvoicePaymentFailed.ts to add failed payments notification
- Added call to usersService.notifyFailedPayment(user.uuid)
- Add handleInvoicePaymentFailed unit test file