### PR TITLE
[PB-4944]: feat/pass drive tier id when updating drive storage

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ export async function buildApp({
 
   fastify.register(controller(paymentService, usersService, config, cacheService, licenseCodesService, tiersService));
   fastify.register(objStorageController(paymentService), { prefix: '/object-storage' });
-  fastify.register(businessController(paymentService, usersService, config), { prefix: '/business' });
+  fastify.register(businessController(paymentService, usersService, tiersService, config), { prefix: '/business' });
   fastify.register(productsController(productsService, cacheService, config), { prefix: '/products' });
   fastify.register(checkoutController(usersService, paymentService), { prefix: '/checkout' });
   fastify.register(customerController(usersService, paymentService, cacheService), { prefix: '/customer' });

--- a/src/controller/business.controller.ts
+++ b/src/controller/business.controller.ts
@@ -101,7 +101,7 @@ export default function (
 
           const price = updatedSub.items.data[0]?.price;
           const productId = typeof price?.product === 'string' ? price.product : price?.product.id;
-          const tier = await tiersService.getTierProductsByProductsId(productId as string, 'subscription');
+          const tier = await tiersService.getTierProductsByProductsId(productId, 'subscription');
 
           await usersService.updateWorkspace({
             ownerId: user.uuid,

--- a/src/core/users/Tier.ts
+++ b/src/core/users/Tier.ts
@@ -7,6 +7,7 @@ interface BackupsFeatures {
 }
 
 export interface DriveFeatures {
+  foreignTierId: string;
   enabled: boolean;
   maxSpaceBytes: number;
   workspaces: {

--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -186,7 +186,7 @@ export class LicenseCodesService {
           await this.tiersService.insertTierToUser(userId, tierProduct.id);
         }
       } else {
-        await this.storageService.changeStorage(user.uuid, maxSpaceBytes);
+        await this.storageService.updateUserStorageAndTier(user.uuid, maxSpaceBytes, '');
       }
     } catch (error) {
       const err = error as Error;

--- a/src/services/licenseCodes.service.ts
+++ b/src/services/licenseCodes.service.ts
@@ -186,7 +186,12 @@ export class LicenseCodesService {
           await this.tiersService.insertTierToUser(userId, tierProduct.id);
         }
       } else {
-        await this.storageService.updateUserStorageAndTier(user.uuid, maxSpaceBytes, '');
+        const freeTier = await this.tiersService.getTierProductsByProductsId('free');
+        await this.storageService.updateUserStorageAndTier(
+          user.uuid,
+          maxSpaceBytes,
+          freeTier.featuresPerService[Service.Drive].foreignTierId,
+        );
       }
     } catch (error) {
       const err = error as Error;

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -18,7 +18,7 @@ export class StorageService {
     private readonly axios: Axios,
   ) {}
 
-  async changeStorage(uuid: string, newStorageBytes: number): Promise<void> {
+  async updateUserStorageAndTier(uuid: string, newStorageBytes: number, foreignTierId: string): Promise<void> {
     const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
     const params: AxiosRequestConfig = {
       headers: {
@@ -30,7 +30,7 @@ export class StorageService {
     try {
       await this.axios.patch(
         `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/users/${uuid}`,
-        { maxSpaceBytes: newStorageBytes },
+        { maxSpaceBytes: newStorageBytes, tierId: foreignTierId },
         params,
       );
     } catch (error) {

--- a/src/services/tiers.service.ts
+++ b/src/services/tiers.service.ts
@@ -248,9 +248,15 @@ export class TiersService {
       const maxSpaceBytes = features.workspaces.maxSpaceBytesPerSeat;
       const address = customer.address?.line1 ?? undefined;
       const phoneNumber = customer.phone ?? undefined;
+      const driveTierId = tier.featuresPerService[Service.Drive].foreignTierId;
 
       try {
-        await this.usersService.updateWorkspaceStorage(userWithEmail.uuid, Number(maxSpaceBytes), subscriptionSeats);
+        await this.usersService.updateWorkspace({
+          ownerId: userWithEmail.uuid,
+          maxSpaceBytes: Number(maxSpaceBytes),
+          seats: subscriptionSeats,
+          tierId: driveTierId,
+        });
         log.info(`[DRIVE/WORKSPACES]: The workspace for user ${userWithEmail.uuid} has been updated`);
       } catch (err) {
         if (isAxiosError(err) && err.response?.status === 404) {
@@ -260,6 +266,7 @@ export class TiersService {
           await this.usersService.initializeWorkspace(userWithEmail.uuid, {
             newStorageBytes: Number(maxSpaceBytes),
             seats: subscriptionSeats,
+            tierId: driveTierId,
             address,
             phoneNumber,
           });

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -168,7 +168,7 @@ export class UsersService {
 
   async initializeWorkspace(
     ownerId: string,
-    payload: { newStorageBytes: number; seats: number; address?: string; phoneNumber?: string },
+    payload: { newStorageBytes: number; seats: number; tierId: string; address?: string; phoneNumber?: string },
   ): Promise<void> {
     const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
     const params: AxiosRequestConfig = {
@@ -182,6 +182,7 @@ export class UsersService {
       `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/workspaces`,
       {
         ownerId,
+        tierId: payload.tierId,
         maxSpaceBytes: payload.newStorageBytes * payload.seats,
         address: payload.address,
         numberOfSeats: payload.seats,
@@ -216,7 +217,17 @@ export class UsersService {
     );
   }
 
-  async updateWorkspaceStorage(ownerId: string, maxSpaceBytes: number, seats: number): Promise<void> {
+  async updateWorkspace({
+    ownerId,
+    tierId,
+    maxSpaceBytes,
+    seats,
+  }: {
+    ownerId: string;
+    tierId: string;
+    maxSpaceBytes: number;
+    seats: number;
+  }): Promise<void> {
     const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
     const requestConfig: AxiosRequestConfig = {
       headers: {
@@ -225,12 +236,13 @@ export class UsersService {
       },
     };
 
-    return this.axios.put(
-      `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/workspaces/storage`,
+    return this.axios.patch(
+      `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/workspaces`,
       {
         ownerId,
         maxSpaceBytes: maxSpaceBytes * seats,
         numberOfSeats: seats,
+        tierId,
       },
       requestConfig,
     );

--- a/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
+++ b/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
@@ -272,7 +272,7 @@ export class InvoiceCompletedHandler {
    * @param maxSpaceBytes The new max space bytes
    */
   private handleOldProduct(userUuid: string, maxSpaceBytes: number): Promise<void> {
-    return this.storageService.changeStorage(userUuid, maxSpaceBytes);
+    return this.storageService.updateUserStorageAndTier(userUuid, maxSpaceBytes, '');
   }
 
   /**

--- a/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
+++ b/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
@@ -271,8 +271,13 @@ export class InvoiceCompletedHandler {
    * @param userUuid The uuid of the user
    * @param maxSpaceBytes The new max space bytes
    */
-  private handleOldProduct(userUuid: string, maxSpaceBytes: number): Promise<void> {
-    return this.storageService.updateUserStorageAndTier(userUuid, maxSpaceBytes, '');
+  private async handleOldProduct(userUuid: string, maxSpaceBytes: number): Promise<void> {
+    const freeTier = await this.tiersService.getTierProductsByProductsId('free');
+    return this.storageService.updateUserStorageAndTier(
+      userUuid,
+      maxSpaceBytes,
+      freeTier.featuresPerService[Service.Drive].foreignTierId,
+    );
   }
 
   /**

--- a/tests/src/controller/business.controller.test.ts
+++ b/tests/src/controller/business.controller.test.ts
@@ -1,0 +1,72 @@
+import { FastifyInstance } from 'fastify';
+import { closeServerAndDatabase, initializeServerAndDatabase } from '../utils/initializeServer';
+import { getCreatedSubscription, getUser, getValidAuthToken, newTier } from '../fixtures';
+import { UsersService } from '../../../src/services/users.service';
+import { PaymentService } from '../../../src/services/payment.service';
+import Stripe from 'stripe';
+import { TiersService } from '../../../src/services/tiers.service';
+import { Service } from '../../../src/core/users/Tier';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await initializeServerAndDatabase();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(async () => {
+  await closeServerAndDatabase();
+});
+
+describe('Testing business endpoints', () => {
+  describe('Updating business subscription', () => {
+    test('When the business is updated, then the Stripe subscription is updated and the workspace in Drive too', async () => {
+      const mockedUser = getUser();
+      const mockedTier = newTier();
+      const mockedSubscription = getCreatedSubscription();
+      const mockedUserToken = getValidAuthToken(mockedUser.uuid);
+      const mockedMaxSpaceBytes = mockedSubscription.items.data[0].price.metadata.maxSpaceBytes;
+      jest.spyOn(UsersService.prototype, 'findUserByUuid').mockResolvedValue(mockedUser);
+      jest
+        .spyOn(PaymentService.prototype, 'getSubscriptionById')
+        .mockResolvedValueOnce(mockedSubscription as Stripe.Response<Stripe.Subscription>);
+      jest.spyOn(PaymentService.prototype, 'getBusinessSubscriptionSeats').mockResolvedValue({
+        minimumSeats: '3',
+        maximumSeats: '10',
+      });
+      jest.spyOn(UsersService.prototype, 'isWorkspaceUpgradeAllowed').mockResolvedValue(true);
+      jest
+        .spyOn(PaymentService.prototype, 'updateBusinessSub')
+        .mockResolvedValueOnce(mockedSubscription as Stripe.Response<Stripe.Subscription>);
+      jest.spyOn(TiersService.prototype, 'getTierProductsByProductsId').mockResolvedValue(mockedTier);
+      const updateWorkspaceSpy = jest.spyOn(UsersService.prototype, 'updateWorkspace').mockResolvedValue();
+
+      const response = await app.inject({
+        path: `/business/subscription`,
+        method: 'PATCH',
+        body: {
+          workspaceId: 'workspace_id',
+          subscriptionId: mockedSubscription.id,
+          workspaceUpdatedSeats: 4,
+        },
+        headers: {
+          Authorization: `Bearer ${mockedUserToken}`,
+        },
+      });
+
+      const responseBody = response.json();
+
+      expect(response.statusCode).toBe(200);
+      expect(responseBody).toStrictEqual(mockedSubscription);
+      expect(updateWorkspaceSpy).toHaveBeenCalledWith({
+        ownerId: mockedUser.uuid,
+        tierId: mockedTier.featuresPerService[Service.Drive].foreignTierId,
+        maxSpaceBytes: Number(mockedMaxSpaceBytes),
+        seats: 4,
+      });
+    });
+  });
+});

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -584,7 +584,9 @@ export const getCreatedSubscription = (
             custom_unit_amount: null,
             livemode: false,
             lookup_key: null,
-            metadata: {},
+            metadata: {
+              maxSpaceBytes: '100',
+            },
             nickname: null,
             product: `prod_${randomDataGenerator.string({ length: 12 })}`,
             recurring: {

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -887,6 +887,7 @@ export const newTier = (params?: Partial<Tier>): Tier => {
       cleaner: { enabled: false },
       drive: {
         enabled: false,
+        foreignTierId: randomUUID(),
         maxSpaceBytes: randomDataGenerator.integer({ min: 1024 * 1024 * 1024, max: 5 * 1024 * 1024 * 1024 }),
         workspaces: {
           enabled: false,

--- a/tests/src/services/licenseCodes.service.test.ts
+++ b/tests/src/services/licenseCodes.service.test.ts
@@ -282,12 +282,20 @@ describe('Tests for License Codes service', () => {
         const mockedCustomer = getCustomer();
         const mockedLogger = getLogger();
         const mockedUser = getUser();
+        const mockedFreeTier = newTier({
+          featuresPerService: {
+            drive: {
+              foreignTierId: 'free',
+            },
+          } as any,
+        });
         const user = {
           uuid: mockedUser.uuid,
           email: mockedCustomer.email as string,
         };
         const maxSpaceBytes = 100;
 
+        jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
         const updateStorageSpy = jest.spyOn(storageService, 'updateUserStorageAndTier').mockResolvedValue();
         await licenseCodesService.applyProductFeatures({
           user,
@@ -297,7 +305,11 @@ describe('Tests for License Codes service', () => {
           tierProduct: null,
         });
 
-        expect(updateStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, maxSpaceBytes, '');
+        expect(updateStorageSpy).toHaveBeenCalledWith(
+          mockedUser.uuid,
+          maxSpaceBytes,
+          mockedFreeTier.featuresPerService.drive.foreignTierId,
+        );
       });
 
       test('When an unexpected error occurs while applying the storage, then an error indicating so is thrown', async () => {
@@ -305,12 +317,20 @@ describe('Tests for License Codes service', () => {
         const mockedCustomer = getCustomer();
         const mockedLogger = getLogger();
         const mockedUser = getUser();
+        const mockedFreeTier = newTier({
+          featuresPerService: {
+            drive: {
+              foreignTierId: 'free',
+            },
+          } as any,
+        });
         const user = {
           uuid: mockedUser.uuid,
           email: mockedCustomer.email as string,
         };
         const maxSpaceBytes = 100;
 
+        jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
         jest.spyOn(storageService, 'updateUserStorageAndTier').mockRejectedValue(unexpectedError);
         await expect(
           licenseCodesService.applyProductFeatures({

--- a/tests/src/services/licenseCodes.service.test.ts
+++ b/tests/src/services/licenseCodes.service.test.ts
@@ -288,7 +288,7 @@ describe('Tests for License Codes service', () => {
         };
         const maxSpaceBytes = 100;
 
-        const updateStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
+        const updateStorageSpy = jest.spyOn(storageService, 'updateUserStorageAndTier').mockResolvedValue();
         await licenseCodesService.applyProductFeatures({
           user,
           customer: mockedCustomer,
@@ -297,7 +297,7 @@ describe('Tests for License Codes service', () => {
           tierProduct: null,
         });
 
-        expect(updateStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, maxSpaceBytes);
+        expect(updateStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, maxSpaceBytes, '');
       });
 
       test('When an unexpected error occurs while applying the storage, then an error indicating so is thrown', async () => {
@@ -311,7 +311,7 @@ describe('Tests for License Codes service', () => {
         };
         const maxSpaceBytes = 100;
 
-        jest.spyOn(storageService, 'changeStorage').mockRejectedValue(unexpectedError);
+        jest.spyOn(storageService, 'updateUserStorageAndTier').mockRejectedValue(unexpectedError);
         await expect(
           licenseCodesService.applyProductFeatures({
             user,

--- a/tests/src/services/products.service.test.ts
+++ b/tests/src/services/products.service.test.ts
@@ -102,6 +102,7 @@ describe('Products Service Tests', () => {
             [Service.Drive]: {
               enabled: true,
               maxSpaceBytes: 1000,
+              foreignTierId: 'individual-random-id',
               workspaces: { enabled: false } as any,
               passwordProtectedSharing: { enabled: true },
               restrictedItemsSharing: { enabled: true },
@@ -132,6 +133,7 @@ describe('Products Service Tests', () => {
             [Service.Drive]: {
               enabled: true,
               maxSpaceBytes: 500,
+              foreignTierId: 'business-random-id',
               workspaces: {
                 enabled: true,
                 maxSpaceBytesPerSeat: 1000,

--- a/tests/src/services/tiers.service.test.ts
+++ b/tests/src/services/tiers.service.test.ts
@@ -483,7 +483,7 @@ describe('TiersService tests', () => {
 
       jest.spyOn(tiersRepository, 'findByProductId').mockImplementation(() => Promise.resolve(tier));
       const updateWorkspaceStorage = jest
-        .spyOn(usersService, 'updateWorkspaceStorage')
+        .spyOn(usersService, 'updateWorkspace')
         .mockImplementation(() => Promise.resolve());
 
       await expect(
@@ -504,7 +504,7 @@ describe('TiersService tests', () => {
 
       jest.spyOn(tiersRepository, 'findByProductId').mockImplementation(() => Promise.resolve(tier));
       const updateWorkspaceStorage = jest
-        .spyOn(usersService, 'updateWorkspaceStorage')
+        .spyOn(usersService, 'updateWorkspace')
         .mockImplementation(() => Promise.resolve());
 
       await tiersService.applyTier(
@@ -515,11 +515,12 @@ describe('TiersService tests', () => {
         logger,
       );
 
-      expect(updateWorkspaceStorage).toHaveBeenCalledWith(
-        userWithEmail.uuid,
-        tier.featuresPerService[Service.Drive].workspaces.maxSpaceBytesPerSeat,
-        mockedInvoiceLineItem.quantity,
-      );
+      expect(updateWorkspaceStorage).toHaveBeenCalledWith({
+        ownerId: userWithEmail.uuid,
+        maxSpaceBytes: tier.featuresPerService[Service.Drive].workspaces.maxSpaceBytesPerSeat,
+        seats: mockedInvoiceLineItem.quantity,
+        tierId: tier.featuresPerService[Service.Drive].foreignTierId,
+      });
     });
 
     it('When workspaces is enabled and the workspace do not exist, then it is initialized', async () => {
@@ -538,7 +539,7 @@ describe('TiersService tests', () => {
         toJSON: () => ({}),
       } as AxiosError;
 
-      jest.spyOn(usersService, 'updateWorkspaceStorage').mockImplementation(() => Promise.reject(axiosError404));
+      jest.spyOn(usersService, 'updateWorkspace').mockImplementation(() => Promise.reject(axiosError404));
 
       const initializeWorkspace = jest.spyOn(usersService, 'initializeWorkspace').mockResolvedValue();
 
@@ -549,6 +550,7 @@ describe('TiersService tests', () => {
         seats: amountOfSeats,
         address: mockedCustomer.address?.line1 ?? undefined,
         phoneNumber: mockedCustomer.phone ?? undefined,
+        tierId: tier.featuresPerService[Service.Drive].foreignTierId,
       });
     });
 
@@ -564,7 +566,7 @@ describe('TiersService tests', () => {
 
       const unexpectedError = new Error('Unexpected error');
 
-      jest.spyOn(usersService, 'updateWorkspaceStorage').mockRejectedValue(unexpectedError);
+      jest.spyOn(usersService, 'updateWorkspace').mockRejectedValue(unexpectedError);
 
       await expect(
         tiersService.applyDriveFeatures(userWithEmail, mockedCustomer, amountOfSeats, tier, logger),

--- a/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
+++ b/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
@@ -367,12 +367,12 @@ describe('Testing the handler when an invoice is completed', () => {
     test('When processing old product, then it should call storage service with correct parameters', async () => {
       const mockedUser = getUser();
       const mockedMaxSpaceBytes = 100;
-      const changeStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
+      const changeStorageSpy = jest.spyOn(storageService, 'updateUserStorageAndTier').mockResolvedValue();
 
       const handleOldProduct = invoiceCompletedHandler['handleOldProduct'].bind(invoiceCompletedHandler);
       await handleOldProduct(mockedUser.uuid, mockedMaxSpaceBytes);
 
-      expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, mockedMaxSpaceBytes);
+      expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, mockedMaxSpaceBytes, '');
     });
   });
 

--- a/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
+++ b/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
@@ -366,13 +366,25 @@ describe('Testing the handler when an invoice is completed', () => {
   describe('Old Product Management', () => {
     test('When processing old product, then it should call storage service with correct parameters', async () => {
       const mockedUser = getUser();
+      const mockedFreeTier = newTier({
+        featuresPerService: {
+          drive: {
+            foreignTierId: 'free',
+          },
+        } as any,
+      });
       const mockedMaxSpaceBytes = 100;
+      jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
       const changeStorageSpy = jest.spyOn(storageService, 'updateUserStorageAndTier').mockResolvedValue();
 
       const handleOldProduct = invoiceCompletedHandler['handleOldProduct'].bind(invoiceCompletedHandler);
       await handleOldProduct(mockedUser.uuid, mockedMaxSpaceBytes);
 
-      expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, mockedMaxSpaceBytes, '');
+      expect(changeStorageSpy).toHaveBeenCalledWith(
+        mockedUser.uuid,
+        mockedMaxSpaceBytes,
+        mockedFreeTier.featuresPerService.drive.foreignTierId,
+      );
     });
   });
 

--- a/tests/src/webhooks/handleLifetimeRefunded.test.ts
+++ b/tests/src/webhooks/handleLifetimeRefunded.test.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 import { TierNotFoundError } from '../../../src/services/tiers.service';
-import { getCharge, getInvoice, getLogger, getUser } from '../fixtures';
+import { getCharge, getInvoice, getLogger, getUser, newTier } from '../fixtures';
 import config from '../../../src/config';
 import { handleCancelPlan } from '../../../src/webhooks/utils/handleCancelPlan';
 import handleLifetimeRefunded from '../../../src/webhooks/handleLifetimeRefunded';
@@ -60,12 +60,21 @@ describe('Process when a lifetime is refunded', () => {
     const mockedUser = getUser();
     const mockedCharge = getCharge();
     const mockedInvoiceLineItems = getInvoice().lines;
+    const mockedFreeTier = newTier({
+      featuresPerService: {
+        drive: {
+          maxSpaceBytes: FREE_PLAN_BYTES_SPACE,
+          foreignTierId: 'free',
+        },
+      } as any,
+    });
 
+    jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
     const getInvoiceLineItemsSpy = jest
       .spyOn(paymentService, 'getInvoiceLineItems')
       .mockResolvedValue(mockedInvoiceLineItems as any);
     const findUserByCustomerIdSpy = jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser);
-    const changeStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
+    const changeStorageSpy = jest.spyOn(storageService, 'updateUserStorageAndTier').mockResolvedValue();
     const updateUserSpy = jest.spyOn(usersService, 'updateUser').mockImplementation();
     (handleCancelPlan as jest.Mock).mockRejectedValue(tierNotFoundError);
 
@@ -84,7 +93,11 @@ describe('Process when a lifetime is refunded', () => {
     expect(getInvoiceLineItemsSpy).toHaveBeenCalledWith(mockedCharge.invoice);
     expect(handleCancelPlan).rejects.toThrow(tierNotFoundError);
     expect(updateUserSpy).toHaveBeenCalledWith(mockedCharge.customer, { lifetime: false });
-    expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
+    expect(changeStorageSpy).toHaveBeenCalledWith(
+      mockedUser.uuid,
+      mockedFreeTier.featuresPerService.drive.maxSpaceBytes,
+      mockedFreeTier.featuresPerService.drive.foreignTierId,
+    );
   });
 
   it('When the cancellation of a subscription that has a Tier is requested and a random error occur, then an error indicating so is thrown', async () => {

--- a/tests/src/webhooks/handleSubscriptionCanceled.test.ts
+++ b/tests/src/webhooks/handleSubscriptionCanceled.test.ts
@@ -1,6 +1,6 @@
 import { TierNotFoundError } from '../../../src/services/tiers.service';
 import { FastifyBaseLogger } from 'fastify';
-import { getCreatedSubscription, getCustomer, getLogger, getProduct, getUser } from '../fixtures';
+import { getCreatedSubscription, getCustomer, getLogger, getProduct, getUser, newTier } from '../fixtures';
 import config from '../../../src/config';
 import handleSubscriptionCanceled from '../../../src/webhooks/handleSubscriptionCanceled';
 import { handleCancelPlan } from '../../../src/webhooks/utils/handleCancelPlan';
@@ -59,12 +59,21 @@ describe('Process when a subscription is cancelled', () => {
     const mockedSubscription = getCreatedSubscription();
     const mockedProduct = getProduct({});
     const mockedCustomer = getCustomer();
+    const mockedFreeTier = newTier({
+      featuresPerService: {
+        drive: {
+          maxSpaceBytes: FREE_PLAN_BYTES_SPACE,
+          foreignTierId: 'free',
+        },
+      } as any,
+    });
     const tierNotFoundError = new TierNotFoundError('Tier not found');
 
+    jest.spyOn(tiersService, 'getTierProductsByProductsId').mockResolvedValue(mockedFreeTier);
     const getProductSpy = jest.spyOn(paymentService, 'getProduct').mockResolvedValue(mockedProduct as any);
     const getCustomerSPy = jest.spyOn(paymentService, 'getCustomer').mockResolvedValue(mockedCustomer as any);
     const findUserByCustomerIdSpy = jest.spyOn(usersService, 'findUserByCustomerID').mockResolvedValue(mockedUser);
-    const changeStorageSpy = jest.spyOn(storageService, 'changeStorage').mockResolvedValue();
+    const changeStorageSpy = jest.spyOn(storageService, 'updateUserStorageAndTier').mockResolvedValue();
     (handleCancelPlan as jest.Mock).mockRejectedValue(tierNotFoundError);
 
     await handleSubscriptionCanceled(
@@ -83,7 +92,11 @@ describe('Process when a subscription is cancelled', () => {
     expect(getCustomerSPy).toHaveBeenCalledWith(mockedSubscription.customer);
     expect(findUserByCustomerIdSpy).toHaveBeenCalledWith(mockedSubscription.customer);
     expect(handleCancelPlan).rejects.toThrow(tierNotFoundError);
-    expect(changeStorageSpy).toHaveBeenCalledWith(mockedUser.uuid, FREE_PLAN_BYTES_SPACE);
+    expect(changeStorageSpy).toHaveBeenCalledWith(
+      mockedUser.uuid,
+      mockedFreeTier.featuresPerService.drive.maxSpaceBytes,
+      mockedFreeTier.featuresPerService.drive.foreignTierId,
+    );
   });
 
   it('When the cancellation of a subscription has a Tier but an unknown error occurs, then an error indicating so is thrown', async () => {


### PR DESCRIPTION
This PR modifies the Drive storage update flow to include the tierId when a user purchases or cancels a subscription.

Previously, only the storage space (`maxSpaceBytes`) was updated, but now Drive needs to know the associated tier to apply the correct policies and configurations.