### PR TITLE
[PB-4945]: feat/command to sync users with tiers in drive

### DIFF
--- a/src/cli/sync-users-with-drive-tiers.ts
+++ b/src/cli/sync-users-with-drive-tiers.ts
@@ -1,0 +1,86 @@
+import axios from 'axios';
+import { MongoClient } from 'mongodb';
+import Stripe from 'stripe';
+
+import envVariablesConfig from '../config';
+import { PaymentService } from '../services/payment.service';
+import { UsersService } from '../services/users.service';
+import { UsersRepository } from '../core/users/UsersRepository';
+import { MongoDBUsersRepository } from '../core/users/MongoDBUsersRepository';
+import { StorageService } from '../services/storage.service';
+import {
+  DisplayBillingRepository,
+  MongoDBDisplayBillingRepository,
+} from '../core/users/MongoDBDisplayBillingRepository';
+import { CouponsRepository } from '../core/coupons/CouponsRepository';
+import { UsersCouponsRepository } from '../core/coupons/UsersCouponsRepository';
+import { MongoDBCouponsRepository } from '../core/coupons/MongoDBCouponsRepository';
+import { MongoDBUsersCouponsRepository } from '../core/coupons/MongoDBUsersCouponsRepository';
+import { ProductsRepository } from '../core/users/ProductsRepository';
+import { MongoDBProductsRepository } from '../core/users/MongoDBProductsRepository';
+import { Bit2MeService } from '../services/bit2me.service';
+import { TiersService } from '../services/tiers.service';
+import { MongoDBTiersRepository, TiersRepository } from '../core/users/MongoDBTiersRepository';
+import { MongoDBUsersTiersRepository, UsersTiersRepository } from '../core/users/MongoDBUsersTiersRepository';
+
+const [, , filePath, provider] = process.argv;
+
+if (!filePath || !provider) {
+  throw new Error('Missing "filePath" or "provider" params');
+}
+
+async function main() {
+  const mongoClient = await new MongoClient(envVariablesConfig.MONGO_URI).connect();
+  try {
+    const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2025-02-24.acacia' });
+    const usersRepository: UsersRepository = new MongoDBUsersRepository(mongoClient);
+    const storageService = new StorageService(envVariablesConfig, axios);
+    const displayBillingRepository: DisplayBillingRepository = new MongoDBDisplayBillingRepository(mongoClient);
+    const couponsRepository: CouponsRepository = new MongoDBCouponsRepository(mongoClient);
+    const usersCouponsRepository: UsersCouponsRepository = new MongoDBUsersCouponsRepository(mongoClient);
+    const productsRepository: ProductsRepository = new MongoDBProductsRepository(mongoClient);
+    const tiersRepository: TiersRepository = new MongoDBTiersRepository(mongoClient);
+    const usersTiersRepository: UsersTiersRepository = new MongoDBUsersTiersRepository(mongoClient);
+    const bit2MeService = new Bit2MeService(
+      envVariablesConfig,
+      axios,
+      envVariablesConfig.CRYPTO_PAYMENTS_PROCESSOR_SECRET_KEY,
+      envVariablesConfig.CRYPTO_PAYMENTS_PROCESSOR_API_KEY,
+      envVariablesConfig.CRYPTO_PAYMENTS_PROCESSOR_API_URL,
+    );
+    const paymentService = new PaymentService(stripe, productsRepository, bit2MeService);
+    const usersService = new UsersService(
+      usersRepository,
+      paymentService,
+      displayBillingRepository,
+      couponsRepository,
+      usersCouponsRepository,
+      envVariablesConfig,
+      axios,
+    );
+    const tiersService = new TiersService(
+      usersService,
+      paymentService,
+      tiersRepository,
+      usersTiersRepository,
+      storageService,
+      envVariablesConfig,
+    );
+
+    const userIdsAndForeignTierId = await usersTiersRepository.getUserTierMappings();
+
+    userIdsAndForeignTierId.map(async ({ userUuid, foreignTierId }) => {
+      await storageService.updateUserStorageAndTier(userUuid, undefined, foreignTierId);
+    });
+  } finally {
+    await mongoClient.close();
+  }
+}
+
+main()
+  .then(() => {
+    console.log('Users and tiers synced');
+  })
+  .catch((err) => {
+    console.error('Error while syncing users: ', err.message);
+  });

--- a/src/core/users/MongoDBUsersTiersRepository.ts
+++ b/src/core/users/MongoDBUsersTiersRepository.ts
@@ -9,6 +9,7 @@ export interface UserTier {
 }
 
 export interface UsersTiersRepository {
+  getUserTierMappings(isBusiness?: boolean): Promise<Array<{ userUuid: string; foreignTierId: string }>>;
   insertTierToUser(userId: User['id'], tierId: Tier['id']): Promise<void>;
   updateUserTier(userId: User['id'], oldTierId: Tier['id'], newTierId: Tier['id']): Promise<boolean>;
   deleteTierFromUser(userId: User['id'], tierId: Tier['id']): Promise<boolean>;
@@ -28,6 +29,55 @@ export class MongoDBUsersTiersRepository implements UsersTiersRepository {
 
   constructor(mongo: MongoClient) {
     this.collection = mongo.db('payments').collection<Omit<UserTier, 'id'>>('users_tiers');
+  }
+
+  async getUserTierMappings(isBusiness = false): Promise<Array<{ userUuid: string; foreignTierId: string }>> {
+    const results = await this.collection
+      .aggregate([
+        {
+          $match: {
+            'featuresPerService.drive.workspaces.enabled': isBusiness,
+          },
+        },
+        {
+          $addFields: {
+            userIdObj: { $toObjectId: '$userId' },
+            tierIdObj: { $toObjectId: '$tierId' },
+          },
+        },
+        {
+          $lookup: {
+            from: 'users',
+            localField: 'userIdObj',
+            foreignField: '_id',
+            as: 'user',
+          },
+        },
+        {
+          $unwind: '$user',
+        },
+        {
+          $lookup: {
+            from: 'tiers',
+            localField: 'tierIdObj',
+            foreignField: '_id',
+            as: 'tier',
+          },
+        },
+        {
+          $unwind: '$tier',
+        },
+        {
+          $project: {
+            _id: 0,
+            userUuid: '$user.uuid',
+            foreignTierId: '$tier.foreignTierId',
+          },
+        },
+      ])
+      .toArray();
+
+    return results as Array<{ userUuid: string; foreignTierId: string }>;
   }
 
   async insertTierToUser(userId: User['id'], tierId: Tier['id']): Promise<void> {

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -18,7 +18,7 @@ export class StorageService {
     private readonly axios: Axios,
   ) {}
 
-  async updateUserStorageAndTier(uuid: string, newStorageBytes: number, foreignTierId: string): Promise<void> {
+  async updateUserStorageAndTier(uuid: string, newStorageBytes?: number, foreignTierId?: string): Promise<void> {
     const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
     const params: AxiosRequestConfig = {
       headers: {

--- a/tests/src/utils/factory.ts
+++ b/tests/src/utils/factory.ts
@@ -24,6 +24,7 @@ const getTiersRepository = (): TiersRepository => {
 
 const getUsersTiersRepository = (): UsersTiersRepository => {
   return {
+    getUserTierMappings: jest.fn(),
     deleteAllUserTiers: jest.fn(),
     deleteTierFromUser: jest.fn(),
     findTierIdByUserId: jest.fn(),


### PR DESCRIPTION
This PR implements a new command in the CLI folder to be able to sync the user with their tier in Drive. 

By passing the business parameter, it will be sync the business subscriptions. By default it syncs the Individual ones (subscription/lifetime).