### PR TITLE
[_]: feat/trust proxy

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -53,7 +53,7 @@ export async function buildApp({
 }: AppDependencies): Promise<FastifyInstance> {
   const fastify = Fastify({
     loggerInstance: Logger.getPinoLogger(),
-    trustProxy: 1,
+    trustProxy: true,
   });
 
   registerErrorHandler(fastify);

--- a/src/app.ts
+++ b/src/app.ts
@@ -53,6 +53,7 @@ export async function buildApp({
 }: AppDependencies): Promise<FastifyInstance> {
   const fastify = Fastify({
     loggerInstance: Logger.getPinoLogger(),
+    trustProxy: 1,
   });
 
   registerErrorHandler(fastify);


### PR DESCRIPTION
Enable trustProxy: 1 in Fastify to correctly resolve the real client IP when running behind Cloudflare.

Without this setting, @fastify/rate-limit uses the proxy IP instead of the user’s IP, causing rate limiting to be applied incorrectly. This change ensures rate limits and request metadata are based on the actual client IP.