### PR TITLE
[_]: fix/suspend-os-account-instead-of-deleting-it-on-sub-cancelled

### DIFF
--- a/src/services/objectStorage.service.ts
+++ b/src/services/objectStorage.service.ts
@@ -47,18 +47,6 @@ export class ObjectStorageService {
     await this.axios.put(`${this.config.OBJECT_STORAGE_URL}/users/${payload.customerId}/deactivate`, {}, params);
   }
 
-  async deleteAccount(payload: { customerId: string }): Promise<void> {
-    const jwt = signToken('5m', this.config.OBJECT_STORAGE_GATEWAY_SECRET);
-    const params: AxiosRequestConfig = {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${jwt}`,
-      },
-    };
-
-    await this.axios.delete(`${this.config.OBJECT_STORAGE_URL}/users/${payload.customerId}`, params);
-  }
-
   private async createUser(email: string, customerId: string): Promise<void> {
     const jwt = signToken('5m', this.config.OBJECT_STORAGE_GATEWAY_SECRET);
     const params: AxiosRequestConfig = {

--- a/src/webhooks/handleSubscriptionCanceled.ts
+++ b/src/webhooks/handleSubscriptionCanceled.ts
@@ -38,7 +38,7 @@ async function handleObjectStorageSubscriptionCancelled(
 
   logger.info(`Deleting object storage customer ${customer.id} with sub ${subscription.id}`);
 
-  await objectStorageService.deleteAccount({
+  await objectStorageService.suspendAccount({
     customerId: customer.id,
   });
 

--- a/src/webhooks/handleSubscriptionUpdated.ts
+++ b/src/webhooks/handleSubscriptionUpdated.ts
@@ -22,7 +22,7 @@ async function handleObjectStorageScheduledForCancelation(
 ): Promise<void> {
   logger.info(`Deleting object storage customer ${customer.id} with sub ${subscription.id}`);
 
-  await objectStorageService.deleteAccount({
+  await objectStorageService.suspendAccount({
     customerId: customer.id,
   });
 


### PR DESCRIPTION
## What 
Suspending instead of deleting accounts on a Stripe's sub cancellation event firing. 

## Why

We have some big clients paying via manual methods so removing those accounts is too aggressive if an unintended payment issue happens and any Stripe config or any Stripe admin cancels the sub due to any global policy or human error. 