### PR TITLE
[_]: fix/remove quantity when creating subscriptions

### DIFF
--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -150,7 +150,6 @@ export class PaymentService {
       items: [
         {
           price: priceId,
-          quantity: 1,
         },
       ],
       discounts: [


### PR DESCRIPTION
Removing the quantity property when creating subscriptions as the default value is 1 and it was breaking object-storage subscriptions (usage-based subscriptions).