### PR TITLE
[_]: refactor/idempotency for handleFundsCaptured event

### DIFF
--- a/src/infrastructure/adapters/stripe.adapter.ts
+++ b/src/infrastructure/adapters/stripe.adapter.ts
@@ -8,6 +8,7 @@ import { PaymentMethod } from '../domain/entities/paymentMethod';
 
 import { UserType } from '../../core/users/User';
 import { Price, PriceInterval } from '../domain/entities/price';
+import { PaymentIntent } from '../domain/entities/paymentIntent';
 
 export class StripePaymentsAdapter implements PaymentsAdapter {
   readonly provider: Stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, {
@@ -104,6 +105,32 @@ export class StripePaymentsAdapter implements PaymentsAdapter {
       decimalAmount: (price.currency_options![currency].unit_amount as number) / 100,
       type: isBusinessPlan ? UserType.Business : UserType.Individual,
       ...businessSeats,
+    });
+  }
+
+  async getPaymentIntent(paymentIntentId: string): Promise<PaymentIntent> {
+    const paymentIntent = await this.provider.paymentIntents.retrieve(paymentIntentId);
+
+    return PaymentIntent.toDomain({
+      id: paymentIntent.id,
+      customer: paymentIntent.customer as string,
+      payment_method: paymentIntent.payment_method as string,
+      metadata: paymentIntent.metadata,
+      status: paymentIntent.status,
+      amount_received: paymentIntent.amount_received,
+    });
+  }
+
+  async cancelPaymentIntent(paymentIntentId: string): Promise<PaymentIntent> {
+    const canceledPaymentIntent = await this.provider.paymentIntents.cancel(paymentIntentId);
+
+    return PaymentIntent.toDomain({
+      id: canceledPaymentIntent.id,
+      customer: canceledPaymentIntent.customer as string,
+      payment_method: canceledPaymentIntent.payment_method as string,
+      metadata: canceledPaymentIntent.metadata,
+      status: canceledPaymentIntent.status,
+      amount_received: canceledPaymentIntent.amount_received,
     });
   }
 

--- a/src/infrastructure/domain/entities/paymentIntent.ts
+++ b/src/infrastructure/domain/entities/paymentIntent.ts
@@ -1,0 +1,34 @@
+export interface PaymentIntentAttributes {
+  id: string;
+  metadata: Record<string, string>;
+  customer: string;
+  status: string;
+  payment_method: string;
+  amount_received: number;
+}
+
+export class PaymentIntent {
+  id: string;
+  metadata: Record<string, string>;
+  customer: string;
+  status: string;
+  payment_method: string;
+  amount_received: number;
+
+  constructor(attributes: PaymentIntentAttributes) {
+    this.id = attributes.id;
+    this.metadata = attributes.metadata;
+    this.customer = attributes.customer;
+    this.status = attributes.status;
+    this.payment_method = attributes.payment_method;
+    this.amount_received = attributes.amount_received;
+  }
+
+  static toDomain(attributes: PaymentIntentAttributes): PaymentIntent {
+    return new PaymentIntent(attributes);
+  }
+
+  public isObjectStorage(): boolean {
+    return this.metadata.type === 'object-storage';
+  }
+}

--- a/src/infrastructure/domain/ports/payments.adapter.ts
+++ b/src/infrastructure/domain/ports/payments.adapter.ts
@@ -1,4 +1,5 @@
 import { Customer, CreateCustomerParams, UpdateCustomerParams } from '../entities/customer';
+import { PaymentIntent } from '../entities/paymentIntent';
 import { PaymentMethod } from '../entities/paymentMethod';
 
 export interface PaymentsAdapter {
@@ -7,4 +8,6 @@ export interface PaymentsAdapter {
   getCustomer: (customerId: Customer['id']) => Promise<Customer>;
   searchCustomer: (email: Customer['email']) => Promise<Customer[]>;
   retrievePaymentMethod: (paymentMethodId: PaymentMethod['id']) => Promise<PaymentMethod>;
+  getPaymentIntent: (paymentIntentId: string) => Promise<PaymentIntent>;
+  cancelPaymentIntent: (paymentIntentId: string) => Promise<PaymentIntent>;
 }

--- a/src/webhooks/handleFundsCaptured.ts
+++ b/src/webhooks/handleFundsCaptured.ts
@@ -1,6 +1,3 @@
-import Stripe from 'stripe';
-import { FastifyBaseLogger } from 'fastify';
-
 import { PaymentService } from '../services/payment.service';
 import { ObjectStorageService } from '../services/objectStorage.service';
 import { ConflictError } from '../errors/Errors';
@@ -8,43 +5,43 @@ import { UserType } from '../core/users/User';
 import axios from 'axios';
 import { VERIFICATION_CHARGE } from '../constants';
 import { stripePaymentsAdapter } from '../infrastructure/adapters/stripe.adapter';
+import { PaymentIntent } from '../infrastructure/domain/entities/paymentIntent';
+import Logger from '../Logger';
 
 export default async function handleFundsCaptured(
-  paymentIntent: Stripe.PaymentIntent,
+  paymentIntent: PaymentIntent,
   paymentsService: PaymentService,
   objectStorageService: ObjectStorageService,
-  stripe: Stripe,
-  logger: FastifyBaseLogger,
 ): Promise<void> {
   const isMissingType = !paymentIntent.metadata.type;
-  const isNotObjectStorage = paymentIntent.metadata.type !== 'object-storage';
   const isMissingPriceId = !paymentIntent.metadata.priceId;
   const isFullVerificationChargeCaptured = paymentIntent.amount_received === VERIFICATION_CHARGE;
 
   const shouldSkipHandling =
-    isMissingType || isNotObjectStorage || isMissingPriceId || isFullVerificationChargeCaptured;
+    isMissingType || !paymentIntent.isObjectStorage() || isMissingPriceId || isFullVerificationChargeCaptured;
 
   if (shouldSkipHandling) {
+    Logger.info(
+      `Received successful payment intent ${paymentIntent.id} from customer ${paymentIntent.customer} but it is not related to Object Storage.`,
+    );
     return;
   }
 
-  logger.info(
-    `Received successful payment intent ${paymentIntent.id} from customer ${paymentIntent.customer as string}`,
-  );
+  Logger.info(`Received successful payment intent ${paymentIntent.id} from customer ${paymentIntent.customer}`);
 
-  const customer = await stripePaymentsAdapter.getCustomer(paymentIntent.customer as string);
+  const customer = await stripePaymentsAdapter.getCustomer(paymentIntent.customer);
 
-  logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) is being initialized...`);
+  Logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) is being initialized...`);
 
   const isPaymentIntentCanceled = paymentIntent.status === 'canceled';
 
   try {
     if (!isPaymentIntentCanceled) {
-      await stripe.paymentIntents.cancel(paymentIntent.id);
+      await stripePaymentsAdapter.cancelPaymentIntent(paymentIntent.id);
     }
   } catch (error) {
     const err = error as Error;
-    logger.error(
+    Logger.error(
       `[OBJECT STORAGE] Unexpected error while attempting to cancel the verification payment intent for user ${customer.id}. Error: ${err.message}`,
     );
 
@@ -60,7 +57,7 @@ export default async function handleFundsCaptured(
         customerId: customer.id,
         priceId: paymentIntent.metadata.priceId,
         additionalOptions: {
-          default_payment_method: paymentIntent.payment_method as string,
+          default_payment_method: paymentIntent.payment_method,
           off_session: true,
           automatic_tax: {
             enabled: true,
@@ -70,7 +67,7 @@ export default async function handleFundsCaptured(
     }
   } catch (error) {
     const err = error as Error;
-    logger.error(
+    Logger.error(
       `[OBJECT STORAGE] Unexpected error while attempting to create a user subscription for user ${customer.id}. Error: ${err.message}`,
     );
 
@@ -87,15 +84,15 @@ export default async function handleFundsCaptured(
       const { status, data } = error.response;
 
       if (status === 409) {
-        logger.error('The user already has an Object Storage account activated');
+        Logger.error('The user already has an Object Storage account activated');
         throw new ConflictError(error.message);
       }
 
-      logger.error(`Unexpected error from Object Storage service [status=${status}]: ${JSON.stringify(data)}`);
+      Logger.error(`Unexpected error from Object Storage service [status=${status}]: ${JSON.stringify(data)}`);
     }
 
     throw error;
   }
 
-  logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) has been initialized!`);
+  Logger.info(`Object Storage for user ${customer.email} (customer ${customer.id}) has been initialized!`);
 }

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -63,9 +63,12 @@ export default function (
           );
           break;
 
-        case 'payment_intent.amount_capturable_updated':
-          await handleFundsCaptured(event.data.object, paymentService, objectStorageService, stripe, fastify.log);
+        case 'payment_intent.amount_capturable_updated': {
+          const paymentIntentId = event.data.object.id;
+          const paymentIntentData = await stripePaymentsAdapter.getPaymentIntent(paymentIntentId);
+          await handleFundsCaptured(paymentIntentData, paymentService, objectStorageService);
           break;
+        }
 
         case 'customer.subscription.deleted':
           await handleSubscriptionCanceled(

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -6,6 +6,7 @@ import { Chance } from 'chance';
 import config from '../../src/config';
 import { User, UserSubscription, UserType } from '../../src/core/users/User';
 import { PaymentIntent, PaymentIntentCrypto, PaymentIntentFiat, PromotionCode } from '../../src/types/payment';
+import { PaymentIntent as PaymentIntentEntity } from '../../src/infrastructure/domain/entities/paymentIntent';
 import { RenewalPeriod, SubscriptionCreated } from '../../src/types/subscription';
 import { Coupon } from '../../src/core/coupons/Coupon';
 import {
@@ -626,6 +627,18 @@ export const getPaymentIntent = (params?: Partial<Stripe.PaymentIntent>): Stripe
     payment_method_types: ['card', 'link'],
     ...params,
   };
+};
+
+export const getPaymentIntentEntity = (params?: Partial<Stripe.PaymentIntent>): PaymentIntentEntity => {
+  const paymentIntent = getPaymentIntent(params);
+  return PaymentIntentEntity.toDomain({
+    id: paymentIntent.id,
+    customer: paymentIntent.customer as string,
+    payment_method: paymentIntent.payment_method as string,
+    metadata: paymentIntent.metadata,
+    status: paymentIntent.status,
+    amount_received: paymentIntent.amount_received,
+  });
 };
 
 export const getCoupon = (params?: Partial<Coupon>): Coupon => ({

--- a/tests/src/infrastructure/adapters/stripe.adapter.test.ts
+++ b/tests/src/infrastructure/adapters/stripe.adapter.test.ts
@@ -1,4 +1,4 @@
-import { getCustomer, getPaymentMethod, getPrice } from '../../fixtures';
+import { getCustomer, getPaymentIntent, getPaymentMethod, getPrice } from '../../fixtures';
 import { stripePaymentsAdapter } from '../../../../src/infrastructure/adapters/stripe.adapter';
 import Stripe from 'stripe';
 import { Customer } from '../../../../src/infrastructure/domain/entities/customer';
@@ -7,6 +7,7 @@ import { PaymentMethod } from '../../../../src/infrastructure/domain/entities/pa
 import { Price } from '../../../../src/infrastructure/domain/entities/price';
 import { UserType } from '../../../../src/core/users/User';
 import { PRODUCT_BASE } from '../../fixtures/stripe-base.generated';
+import { PaymentIntent } from '../../../../src/infrastructure/domain/entities/paymentIntent';
 
 describe('Stripe Adapter', () => {
   describe('Create customer', () => {
@@ -388,6 +389,88 @@ describe('Stripe Adapter', () => {
       const price = await stripePaymentsAdapter.getPriceById(stripePrice.id, 'eur');
 
       expect(price.interval).toBe('lifetime');
+    });
+  });
+
+  describe('Get payment intent', () => {
+    test('When retrieving a payment intent, then the mapped domain entity is returned', async () => {
+      const stripePaymentIntent = getPaymentIntent({
+        customer: 'cus_test123',
+        payment_method: 'pm_test123',
+        metadata: { type: 'object-storage', priceId: 'price_abc' },
+        status: 'succeeded',
+        amount_received: 100,
+      });
+
+      jest
+        .spyOn(stripePaymentsAdapter.provider.paymentIntents, 'retrieve')
+        .mockResolvedValue(stripePaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+
+      const result = await stripePaymentsAdapter.getPaymentIntent(stripePaymentIntent.id);
+
+      expect(result).toStrictEqual(
+        PaymentIntent.toDomain({
+          id: stripePaymentIntent.id,
+          customer: stripePaymentIntent.customer as string,
+          payment_method: stripePaymentIntent.payment_method as string,
+          metadata: stripePaymentIntent.metadata,
+          status: stripePaymentIntent.status,
+          amount_received: stripePaymentIntent.amount_received,
+        }),
+      );
+    });
+
+    test('When retrieving a payment intent, then the Stripe API is called with the correct ID', async () => {
+      const stripePaymentIntent = getPaymentIntent();
+
+      const retrieveSpy = jest
+        .spyOn(stripePaymentsAdapter.provider.paymentIntents, 'retrieve')
+        .mockResolvedValue(stripePaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+
+      await stripePaymentsAdapter.getPaymentIntent(stripePaymentIntent.id);
+
+      expect(retrieveSpy).toHaveBeenCalledWith(stripePaymentIntent.id);
+    });
+  });
+
+  describe('Cancel payment intent', () => {
+    test('When cancelling a payment intent, then the cancelled domain entity is returned', async () => {
+      const stripePaymentIntent = getPaymentIntent({
+        customer: 'cus_test123',
+        payment_method: 'pm_test123',
+        metadata: { type: 'object-storage', priceId: 'price_abc' },
+        status: 'canceled',
+        amount_received: 0,
+      });
+
+      jest
+        .spyOn(stripePaymentsAdapter.provider.paymentIntents, 'cancel')
+        .mockResolvedValue(stripePaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+
+      const result = await stripePaymentsAdapter.cancelPaymentIntent(stripePaymentIntent.id);
+
+      expect(result).toStrictEqual(
+        PaymentIntent.toDomain({
+          id: stripePaymentIntent.id,
+          customer: stripePaymentIntent.customer as string,
+          payment_method: stripePaymentIntent.payment_method as string,
+          metadata: stripePaymentIntent.metadata,
+          status: stripePaymentIntent.status,
+          amount_received: stripePaymentIntent.amount_received,
+        }),
+      );
+    });
+
+    test('When cancelling a payment intent, then the Stripe API is called with the correct ID', async () => {
+      const stripePaymentIntent = getPaymentIntent();
+
+      const cancelSpy = jest
+        .spyOn(stripePaymentsAdapter.provider.paymentIntents, 'cancel')
+        .mockResolvedValue(stripePaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+
+      await stripePaymentsAdapter.cancelPaymentIntent(stripePaymentIntent.id);
+
+      expect(cancelSpy).toHaveBeenCalledWith(stripePaymentIntent.id);
     });
   });
 });

--- a/tests/src/webhooks/handleFundsCaptured.test.ts
+++ b/tests/src/webhooks/handleFundsCaptured.test.ts
@@ -1,6 +1,4 @@
-import Stripe from 'stripe';
-import { getPaymentIntent, getLogger, getCustomer, getCreateSubscriptionResponse } from '../fixtures';
-import { FastifyBaseLogger } from 'fastify';
+import { getPaymentIntentEntity, getCustomer, getCreateSubscriptionResponse } from '../fixtures';
 import handleFundsCaptured from '../../../src/webhooks/handleFundsCaptured';
 import { ConflictError, InternalServerError } from '../../../src/errors/Errors';
 import { UserSubscription, UserType } from '../../../src/core/users/User';
@@ -8,14 +6,12 @@ import { createTestServices } from '../helpers/services-factory';
 import { stripePaymentsAdapter } from '../../../src/infrastructure/adapters/stripe.adapter';
 import { Customer } from '../../../src/infrastructure/domain/entities/customer';
 
-const logger: jest.Mocked<FastifyBaseLogger> = getLogger();
-
 const stripeMock = {
   paymentIntents: {
     cancel: jest.fn(),
   },
 };
-const { paymentService, objectStorageService, stripe } = createTestServices({
+const { paymentService, objectStorageService } = createTestServices({
   stripe: stripeMock,
 });
 
@@ -27,36 +23,36 @@ beforeEach(() => {
 describe('Handling captured funds from a payment method', () => {
   describe('Checking the metadata', () => {
     it('When the payment intent does not contains the object-storage type in the metadata, then do nothing', async () => {
-      const mockPaymentIntent = getPaymentIntent();
+      const mockPaymentIntent = getPaymentIntentEntity();
       const getCustomerSpy = jest.spyOn(stripePaymentsAdapter, 'getCustomer');
 
-      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger);
+      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService);
 
       expect(getCustomerSpy).not.toHaveBeenCalled();
     });
 
     it('When the payment intent has a type value in metadata but it is not object-storage, then do nothing', async () => {
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: {
           type: 'business',
         },
       });
       const getCustomerSpy = jest.spyOn(stripePaymentsAdapter, 'getCustomer');
 
-      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger);
+      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService);
 
       expect(getCustomerSpy).not.toHaveBeenCalled();
     });
 
     it('When the payment intent contains the type but not the ID of the price the user wants to subscribe to, then do nothing', async () => {
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: {
           type: 'object-storage',
         },
       });
       const getCustomerSpy = jest.spyOn(stripePaymentsAdapter, 'getCustomer');
 
-      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger);
+      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService);
 
       expect(getCustomerSpy).not.toHaveBeenCalled();
     });
@@ -65,7 +61,7 @@ describe('Handling captured funds from a payment method', () => {
   describe('Cancelling the Verification Payment Intent', () => {
     it('When the payment intent has been already cancelled, then the payment intent cancellation is skipped', async () => {
       const mockedPrice = 'price_id';
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: { type: 'object-storage', priceId: mockedPrice },
         status: 'canceled',
       });
@@ -73,7 +69,7 @@ describe('Handling captured funds from a payment method', () => {
       const mockSubscription = getCreateSubscriptionResponse();
 
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
-      const cancelPaymentIntentSpy = jest.spyOn(stripe.paymentIntents, 'cancel');
+      const cancelPaymentIntentSpy = jest.spyOn(stripePaymentsAdapter, 'cancelPaymentIntent');
       const getUserSubscriptionSpy = jest
         .spyOn(paymentService, 'getUserSubscription')
         .mockResolvedValue({ type: 'free' });
@@ -84,7 +80,7 @@ describe('Handling captured funds from a payment method', () => {
         .spyOn(objectStorageService, 'initObjectStorageUser')
         .mockResolvedValue();
 
-      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger);
+      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService);
 
       expect(cancelPaymentIntentSpy).not.toHaveBeenCalled();
       expect(getUserSubscriptionSpy).toHaveBeenCalledWith(mockCustomer.id, UserType.ObjectStorage);
@@ -108,14 +104,14 @@ describe('Handling captured funds from a payment method', () => {
     it('When an unexpected error occurs while cancelling the payment intent, then an error indicating so is thrown', async () => {
       const unexpectedError = new InternalServerError('Unexpected Error');
       const mockedPrice = 'price_id';
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: { type: 'object-storage', priceId: mockedPrice },
       });
       const mockCustomer = getCustomer();
       const mockSubscription = getCreateSubscriptionResponse();
 
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
-      jest.spyOn(stripe.paymentIntents, 'cancel').mockRejectedValue(unexpectedError);
+      jest.spyOn(stripePaymentsAdapter, 'cancelPaymentIntent').mockRejectedValue(unexpectedError);
       const getUserSubscriptionSpy = jest
         .spyOn(paymentService, 'getUserSubscription')
         .mockResolvedValue({ type: 'free' });
@@ -126,9 +122,9 @@ describe('Handling captured funds from a payment method', () => {
         .spyOn(objectStorageService, 'initObjectStorageUser')
         .mockResolvedValue();
 
-      await expect(
-        handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger),
-      ).rejects.toThrow(unexpectedError);
+      await expect(handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService)).rejects.toThrow(
+        unexpectedError,
+      );
 
       expect(getUserSubscriptionSpy).not.toHaveBeenCalled();
       expect(createdSubscriptionSpy).not.toHaveBeenCalled();
@@ -139,7 +135,7 @@ describe('Handling captured funds from a payment method', () => {
   describe('Creating object storage subscription', () => {
     it('When the subscription is already created, then the creation of the subscription is skipped', async () => {
       const mockedPrice = 'price_id';
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: { type: 'object-storage', priceId: mockedPrice },
       });
       const mockCustomer = getCustomer();
@@ -147,8 +143,8 @@ describe('Handling captured funds from a payment method', () => {
 
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
       const cancelPaymentIntentSpy = jest
-        .spyOn(stripe.paymentIntents, 'cancel')
-        .mockResolvedValue(mockPaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+        .spyOn(stripePaymentsAdapter, 'cancelPaymentIntent')
+        .mockResolvedValue(mockPaymentIntent);
       const getUserSubscriptionSpy = jest
         .spyOn(paymentService, 'getUserSubscription')
         .mockResolvedValue({ type: 'subscription' } as unknown as UserSubscription);
@@ -159,7 +155,7 @@ describe('Handling captured funds from a payment method', () => {
         .spyOn(objectStorageService, 'initObjectStorageUser')
         .mockResolvedValue();
 
-      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger);
+      await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService);
 
       expect(cancelPaymentIntentSpy).toHaveBeenCalledWith(mockPaymentIntent.id);
       expect(getUserSubscriptionSpy).toHaveBeenCalledWith(mockCustomer.id, UserType.ObjectStorage);
@@ -173,7 +169,7 @@ describe('Handling captured funds from a payment method', () => {
     it('When an error occurs while creating subscription, then an error indicating so is thrown', async () => {
       const unexpectedError = new InternalServerError('Something went wrong while creating subscription');
       const mockedPrice = 'price_id';
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: { type: 'object-storage', priceId: mockedPrice },
       });
       const mockCustomer = getCustomer();
@@ -181,8 +177,8 @@ describe('Handling captured funds from a payment method', () => {
 
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
       const cancelPaymentIntentSpy = jest
-        .spyOn(stripe.paymentIntents, 'cancel')
-        .mockResolvedValue(mockPaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+        .spyOn(stripePaymentsAdapter, 'cancelPaymentIntent')
+        .mockResolvedValue(mockPaymentIntent);
       const getUserSubscriptionSpy = jest
         .spyOn(paymentService, 'getUserSubscription')
         .mockRejectedValue(unexpectedError);
@@ -193,9 +189,9 @@ describe('Handling captured funds from a payment method', () => {
         .spyOn(objectStorageService, 'initObjectStorageUser')
         .mockResolvedValue();
 
-      await expect(
-        handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger),
-      ).rejects.toThrow(unexpectedError);
+      await expect(handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService)).rejects.toThrow(
+        unexpectedError,
+      );
 
       expect(cancelPaymentIntentSpy).toHaveBeenCalledWith(mockPaymentIntent.id);
       expect(getUserSubscriptionSpy).toHaveBeenCalledWith(mockCustomer.id, UserType.ObjectStorage);
@@ -206,7 +202,7 @@ describe('Handling captured funds from a payment method', () => {
 
   it('When the funds are captured, then the payment intent is cancelled, the subscription is created and the object storage account is initialized', async () => {
     const mockedPrice = 'price_id';
-    const mockPaymentIntent = getPaymentIntent({
+    const mockPaymentIntent = getPaymentIntentEntity({
       metadata: { type: 'object-storage', priceId: mockedPrice },
     });
     const mockCustomer = getCustomer();
@@ -214,8 +210,8 @@ describe('Handling captured funds from a payment method', () => {
 
     jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
     const cancelPaymentIntentSpy = jest
-      .spyOn(stripe.paymentIntents, 'cancel')
-      .mockResolvedValue(mockPaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+      .spyOn(stripePaymentsAdapter, 'cancelPaymentIntent')
+      .mockResolvedValue(mockPaymentIntent);
     const getUserSubscriptionSpy = jest
       .spyOn(paymentService, 'getUserSubscription')
       .mockResolvedValue({ type: 'free' });
@@ -224,7 +220,7 @@ describe('Handling captured funds from a payment method', () => {
       .spyOn(objectStorageService, 'initObjectStorageUser')
       .mockResolvedValue();
 
-    await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger);
+    await handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService);
 
     expect(cancelPaymentIntentSpy).toHaveBeenCalledWith(mockPaymentIntent.id);
     expect(getUserSubscriptionSpy).toHaveBeenCalledWith(mockCustomer.id, UserType.ObjectStorage);
@@ -248,16 +244,14 @@ describe('Handling captured funds from a payment method', () => {
   describe('Initializing Object Storage account', () => {
     it('if the user already has an account activated, then an error indicating so is thrown', async () => {
       const mockedPrice = 'price_id';
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: { type: 'object-storage', priceId: mockedPrice },
       });
       const mockCustomer = getCustomer();
       const mockSubscription = getCreateSubscriptionResponse();
 
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
-      jest
-        .spyOn(stripe.paymentIntents, 'cancel')
-        .mockResolvedValue(mockPaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+      jest.spyOn(stripePaymentsAdapter, 'cancelPaymentIntent').mockResolvedValue(mockPaymentIntent);
       jest.spyOn(paymentService, 'getUserSubscription').mockResolvedValue({ type: 'free' });
       jest.spyOn(paymentService, 'createSubscription').mockResolvedValue(mockSubscription);
       jest.spyOn(objectStorageService, 'initObjectStorageUser').mockRejectedValue({
@@ -269,32 +263,29 @@ describe('Handling captured funds from a payment method', () => {
         message: 'Conflict',
       });
 
-      await expect(
-        handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger),
-      ).rejects.toThrow(ConflictError);
-      expect(logger.error).toHaveBeenCalledWith('The user already has an Object Storage account activated');
+      await expect(handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService)).rejects.toThrow(
+        ConflictError,
+      );
     });
 
     it('if an unexpected error occurs while initializing the object storage account, then an error indicating so is thrown', async () => {
       const mockedPrice = 'price_id';
       const unexpectedError = new InternalServerError('Unexpected Error');
-      const mockPaymentIntent = getPaymentIntent({
+      const mockPaymentIntent = getPaymentIntentEntity({
         metadata: { type: 'object-storage', priceId: mockedPrice },
       });
       const mockCustomer = getCustomer();
       const mockSubscription = getCreateSubscriptionResponse();
 
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(Customer.toDomain(mockCustomer));
-      jest
-        .spyOn(stripe.paymentIntents, 'cancel')
-        .mockResolvedValue(mockPaymentIntent as Stripe.Response<Stripe.PaymentIntent>);
+      jest.spyOn(stripePaymentsAdapter, 'cancelPaymentIntent').mockResolvedValue(mockPaymentIntent);
       jest.spyOn(paymentService, 'getUserSubscription').mockResolvedValue({ type: 'free' });
       jest.spyOn(paymentService, 'createSubscription').mockResolvedValue(mockSubscription);
       jest.spyOn(objectStorageService, 'initObjectStorageUser').mockRejectedValue(unexpectedError);
 
-      await expect(
-        handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService, stripe, logger),
-      ).rejects.toThrow(unexpectedError);
+      await expect(handleFundsCaptured(mockPaymentIntent, paymentService, objectStorageService)).rejects.toThrow(
+        unexpectedError,
+      );
     });
   });
 });

--- a/tests/src/webhooks/webhook.test.ts
+++ b/tests/src/webhooks/webhook.test.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { closeServerAndDatabase, initializeServerAndDatabase } from '../utils/initializeServer';
 import Stripe from 'stripe';
-import { getCustomer, getInvoice, getPaymentIntent, getPaymentMethod } from '../fixtures';
+import { getCustomer, getInvoice, getPaymentIntent, getPaymentIntentEntity, getPaymentMethod } from '../fixtures';
 import handleFundsCaptured from '../../../src/webhooks/handleFundsCaptured';
 import { PaymentService } from '../../../src/services/payment.service';
 import { ObjectStorageService } from '../../../src/services/objectStorage.service';
@@ -32,12 +32,17 @@ describe('Webhook events', () => {
   describe('The webhooks are called correctly', () => {
     test('When the event payment_intent.amount_capturable_updated is triggered, then the correct function is called', async () => {
       const mockedPaymentIntent = getPaymentIntent();
+      const mockedPaymentIntentEntity = getPaymentIntentEntity({ id: mockedPaymentIntent.id });
       const event = {
         id: 'evt_1',
         type: 'payment_intent.amount_capturable_updated',
         data: { object: mockedPaymentIntent },
       };
       const payloadToString = JSON.stringify(event);
+
+      jest
+        .spyOn(StripePaymentsAdapter.prototype, 'getPaymentIntent')
+        .mockResolvedValue(mockedPaymentIntentEntity);
 
       const header = Stripe.webhooks.generateTestHeaderString({
         payload: payloadToString,
@@ -55,13 +60,10 @@ describe('Webhook events', () => {
       });
 
       expect(response.statusCode).toBe(204);
-      expect(handleFundsCaptured).toHaveBeenCalled();
       expect(handleFundsCaptured).toHaveBeenCalledWith(
-        event.data.object,
+        mockedPaymentIntentEntity,
         expect.any(PaymentService),
         expect.any(ObjectStorageService),
-        expect.any(Stripe),
-        app.log,
       );
     });
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ES6",
     "lib": ["ES6", "DOM"],
     "allowJs": true,
-    "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Make the `funds_captured` event handler idempotent to ensure safe retries and consistent behavior in failure scenarios.

With this change, repeated processing of the same event will no longer produce duplicate side effects. If the handler fails midway and the event is retried, execution will resume safely and the system will reach the expected final state.