### PR TITLE
[_]: fix/cancellation trial security issue

### DIFF
--- a/src/controller/customer.controller.ts
+++ b/src/controller/customer.controller.ts
@@ -79,25 +79,9 @@ export function customerController(
       },
     );
 
-    fastify.post<{
-      Body: {
-        subscriptionId: string;
-      };
-    }>(
+    fastify.post(
       '/cancellation-trial',
       {
-        schema: {
-          body: {
-            type: 'object',
-            required: ['subscriptionId'],
-            properties: {
-              subscriptionId: {
-                type: 'string',
-                description: 'The ID of the subscription to apply the cancellation trial',
-              },
-            },
-          },
-        },
         config: {
           rateLimit: {
             max: 5,
@@ -107,7 +91,6 @@ export function customerController(
       },
       async (req, res) => {
         const { uuid } = req.user.payload;
-        const { subscriptionId } = req.body;
         const user = await usersService.findUserByUuid(uuid);
 
         const hasRedeemedCancellationTrial = await usersService.hasRedeemedCancellationTrial(user.customerId);
@@ -116,7 +99,9 @@ export function customerController(
           throw new CancellationTrialAlreadyRedeemedError();
         }
 
-        await paymentService.applyCancellationTrial(subscriptionId);
+        const subscription = await paymentService.getActiveSubscriptionEntity(user.customerId);
+
+        await paymentService.applyCancellationTrial(subscription);
 
         await usersService.redeemCancellationTrial(user.customerId);
 

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -523,13 +523,12 @@ export class PaymentService {
     };
   }
 
-  async applyCancellationTrial(subscriptionId: SubscriptionId): Promise<void> {
-    const subscription = await stripePaymentsAdapter.getSubscription(subscriptionId);
+  async applyCancellationTrial(subscription: SubscriptionEntity): Promise<void> {
     const { isElegibleForCancellation } = this.getAnnualCommitmentCancellationInfo(subscription);
     if (!isElegibleForCancellation) throw new BadRequestError('The trial cannot be applied.');
 
     const trialEnd = dayjs.unix(subscription.currentPeriodEnd).add(1, 'month').unix();
-    await stripePaymentsAdapter.updateSubscription(subscriptionId, {
+    await stripePaymentsAdapter.updateSubscription(subscription.id, {
       trial_end: trialEnd,
       proration_behavior: 'none',
     });

--- a/tests/src/controller/customer.controller.test.ts
+++ b/tests/src/controller/customer.controller.test.ts
@@ -5,6 +5,7 @@ import { UsersService } from '../../../src/services/users.service';
 import { PaymentService } from '../../../src/services/payment.service';
 import CacheService from '../../../src/services/cache.service';
 import { UserNotFoundError } from '../../../src/errors/PaymentErrors';
+import { getSubscriptionEntity } from '../entity.fixtures';
 
 let app: FastifyInstance;
 
@@ -135,9 +136,6 @@ describe('Customer controller', () => {
       const response = await app.inject({
         path: `/customer/cancellation-trial`,
         method: 'POST',
-        body: {
-          subscriptionId: 'subscription-id',
-        },
         headers: {
           authorization: `Bearer ${mockedToken}`,
         },
@@ -155,9 +153,6 @@ describe('Customer controller', () => {
       const response = await app.inject({
         path: `/customer/cancellation-trial`,
         method: 'POST',
-        body: {
-          subscriptionId: 'subscription-id',
-        },
         headers: {
           authorization: `Bearer ${mockedToken}`,
         },
@@ -168,18 +163,17 @@ describe('Customer controller', () => {
 
     test('When the customer is elegible, then the cancellation trial is applied', async () => {
       const mockedUser = getUser();
+      const mockedSubscriptionEntity = getSubscriptionEntity();
       const mockedToken = getValidAuthToken(mockedUser.uuid);
       jest.spyOn(UsersService.prototype, 'findUserByUuid').mockResolvedValue(mockedUser);
       jest.spyOn(UsersService.prototype, 'hasRedeemedCancellationTrial').mockResolvedValue(false);
+      jest.spyOn(PaymentService.prototype, 'getActiveSubscriptionEntity').mockResolvedValue(mockedSubscriptionEntity);
       jest.spyOn(PaymentService.prototype, 'applyCancellationTrial').mockResolvedValue();
       const redeemSpy = jest.spyOn(UsersService.prototype, 'redeemCancellationTrial').mockResolvedValue();
 
       const response = await app.inject({
         path: `/customer/cancellation-trial`,
         method: 'POST',
-        body: {
-          subscriptionId: 'subscription-id',
-        },
         headers: {
           authorization: `Bearer ${mockedToken}`,
         },


### PR DESCRIPTION
Avoid passing the subscription ID in the request body, as this could allow a user to cancel a subscription they do not own. Instead, retrieve the authenticated user's active subscription using the user authentication token, and use that subscription for the cancellation request.