### PR TITLE
[PB-6371]: feature/expose endpoint for cancellation flow for users outside refund period

### DIFF
--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import jwt from 'jsonwebtoken';
 import { type AppConfig } from '../config';
 import { UsersService } from '../services/users.service';
@@ -274,6 +274,15 @@ export function paymentsController(
         }
       },
     );
+
+    fastify.post('/subscriptions/cancel-early-charge', async (req: FastifyRequest, rep: FastifyReply) => {
+      const user = await assertUser(req, rep, usersService);
+
+      const subscription = await paymentService.getActiveSubscriptionEntity(user.customerId, UserType.Individual);
+
+      const { clientSecret } = await paymentService.createEarlyCancellationCharge(subscription);
+      return rep.send({ clientSecret });
+    });
 
     fastify.post<{
       Body: { customerId: string };

--- a/src/infrastructure/adapters/stripe.adapter.ts
+++ b/src/infrastructure/adapters/stripe.adapter.ts
@@ -151,6 +151,10 @@ export class StripePaymentsAdapter implements PaymentsAdapter {
     });
   }
 
+  async deleteSubscription(subscriptionId: string): Promise<void> {
+    await this.provider.subscriptions.cancel(subscriptionId);
+  }
+
   async createInvoice(params?: Partial<Stripe.InvoiceCreateParams>): Promise<Invoice> {
     const invoice = await this.provider.invoices.create(params);
 

--- a/src/infrastructure/adapters/stripe.adapter.ts
+++ b/src/infrastructure/adapters/stripe.adapter.ts
@@ -151,7 +151,7 @@ export class StripePaymentsAdapter implements PaymentsAdapter {
     });
   }
 
-  async deleteSubscription(subscriptionId: string): Promise<void> {
+  async cancelSubscription(subscriptionId: string): Promise<void> {
     await this.provider.subscriptions.cancel(subscriptionId);
   }
 

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -462,7 +462,7 @@ export class PaymentService {
       return;
     }
 
-    await stripePaymentsAdapter.deleteSubscription(subscriptionId);
+    await stripePaymentsAdapter.cancelSubscription(subscriptionId);
   }
 
   private calculateRemainingSubscriptionAmount(price: Price, remainingMonths: number): number {

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -462,7 +462,7 @@ export class PaymentService {
       return;
     }
 
-    await this.provider.subscriptions.cancel(subscriptionId, {});
+    await stripePaymentsAdapter.deleteSubscription(subscriptionId);
   }
 
   private calculateRemainingSubscriptionAmount(price: Price, remainingMonths: number): number {
@@ -473,7 +473,7 @@ export class PaymentService {
     return amountToCharge;
   }
 
-  async chargeRemainingSubscriptionAmount(subscriptionEntity: SubscriptionEntity): Promise<{
+  async createEarlyCancellationCharge(subscriptionEntity: SubscriptionEntity): Promise<{
     clientSecret?: string;
   }> {
     const customer = await stripePaymentsAdapter.getCustomer(subscriptionEntity.customer);

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -928,6 +928,13 @@ export class PaymentService {
     const subscriptionEntity = this.mapToSubscriptionEntity(subscription);
     const commitment = hasAnnualCommitment ? this.getAnnualCommitmentCancellationInfo(subscriptionEntity) : null;
 
+    let earlyCancellationFee: number | undefined;
+    if (hasAnnualCommitment) {
+      const priceEntity = await stripePaymentsAdapter.getPriceById(subscriptionEntity.priceId);
+      earlyCancellationFee =
+        this.calculateRemainingSubscriptionAmount(priceEntity, commitment?.remainingMonths || 0) * 0.01;
+    }
+
     const plan: PlanSubscription = {
       status: subscription.status,
       planId: subscription.plan.id,
@@ -954,9 +961,14 @@ export class PaymentService {
         remainingMonths: commitment?.remainingMonths,
         cancellationDate: commitment?.cancellationDate,
         isElegibleForCancellation: commitment?.isElegibleForCancellation,
+        earlyCancellationFee,
       },
       cancellationTrial: {
         redeemed: hasRedeemedCancellationTrial ?? false,
+      },
+      cancellation: {
+        scheduled: !!subscription.cancel_at,
+        cancelAt: subscription.cancel_at ?? undefined,
       },
       storageLimit: storageLimit,
       amountOfSeats: item.quantity || 1,

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -27,11 +27,16 @@ export interface PlanSubscription {
     remainingMonths?: number;
     cancellationDate?: string;
     isElegibleForCancellation?: boolean;
+    earlyCancellationFee?: number;
   };
   storageLimit: number;
   amountOfSeats: number;
   cancellationTrial: {
     redeemed: boolean;
+  };
+  cancellation: {
+    scheduled: boolean;
+    cancelAt?: number;
   };
   seats?: {
     minimumSeats: number;

--- a/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
+++ b/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
@@ -85,7 +85,7 @@ export class InvoiceCompletedHandler {
     // If the invoice is for early cancellation, cancel the subscription
     if (isChargeRemainingSubscriptionAmount && subscriptionId) {
       Logger.info(`Invoice ${invoiceId} is for early cancellation, cancelling subscription...`);
-      await stripePaymentsAdapter.deleteSubscription(subscriptionId);
+      await stripePaymentsAdapter.cancelSubscription(subscriptionId);
       return;
     }
 

--- a/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
+++ b/src/webhooks/events/invoices/InvoiceCompletedHandler.ts
@@ -1,6 +1,5 @@
 import Stripe from 'stripe';
 import { DetermineLifetimeConditions } from '../../../core/users/DetermineLifetimeConditions';
-import { FastifyBaseLogger } from 'fastify';
 import { PaymentService } from '../../../services/payment.service';
 import { PriceMetadata } from '../../../types/stripe';
 import { User, UserType } from '../../../core/users/User';
@@ -15,6 +14,18 @@ import Logger from '../../../Logger';
 import { UserNotFoundError } from '../../../errors/PaymentErrors';
 import { Customer } from '../../../infrastructure/domain/entities/customer';
 import { CouponNotBeingTrackedError } from '../../../errors/UsersErrors';
+import { SUBSCRIPTION_EARLY_CANCELLATION_KEY } from '../../../constants';
+import { stripePaymentsAdapter } from '../../../infrastructure/adapters/stripe.adapter';
+
+interface InvoiceCompletedHandlerAttributes {
+  determineLifetimeConditions: DetermineLifetimeConditions;
+  objectStorageWebhookHandler: ObjectStorageWebhookHandler;
+  paymentService: PaymentService;
+  storageService: StorageService;
+  tiersService: TiersService;
+  usersService: UsersService;
+  cacheService: CacheService;
+}
 
 export interface InvoiceCompletedHandlerPayload {
   customer: Customer;
@@ -23,7 +34,6 @@ export interface InvoiceCompletedHandlerPayload {
 }
 
 export class InvoiceCompletedHandler {
-  private readonly logger: FastifyBaseLogger;
   private readonly determineLifetimeConditions: DetermineLifetimeConditions;
   private readonly objectStorageWebhookHandler: ObjectStorageWebhookHandler;
   private readonly paymentService: PaymentService;
@@ -33,7 +43,6 @@ export class InvoiceCompletedHandler {
   private readonly cacheService: CacheService;
 
   constructor({
-    logger,
     determineLifetimeConditions,
     objectStorageWebhookHandler,
     paymentService,
@@ -41,17 +50,7 @@ export class InvoiceCompletedHandler {
     tiersService,
     usersService,
     cacheService,
-  }: {
-    logger: FastifyBaseLogger;
-    determineLifetimeConditions: DetermineLifetimeConditions;
-    objectStorageWebhookHandler: ObjectStorageWebhookHandler;
-    paymentService: PaymentService;
-    storageService: StorageService;
-    tiersService: TiersService;
-    usersService: UsersService;
-    cacheService: CacheService;
-  }) {
-    this.logger = logger;
+  }: InvoiceCompletedHandlerAttributes) {
     this.determineLifetimeConditions = determineLifetimeConditions;
     this.objectStorageWebhookHandler = objectStorageWebhookHandler;
     this.paymentService = paymentService;
@@ -73,11 +72,20 @@ export class InvoiceCompletedHandler {
     const customerId = customer.id;
     const customerEmail = customer.email;
     const isInvoicePaid = invoiceStatus === 'paid';
+    const isChargeRemainingSubscriptionAmount = invoice.metadata?.type === SUBSCRIPTION_EARLY_CANCELLATION_KEY;
+    const subscriptionId = invoice.metadata?.subscriptionId;
 
     Logger.info(`Processing invoice ${invoiceId} for customer ${customerId}...`);
 
     if (!isInvoicePaid) {
       Logger.info(`Invoice ${invoiceId} not paid, skipping processing`);
+      return;
+    }
+
+    // If the invoice is for early cancellation, cancel the subscription
+    if (isChargeRemainingSubscriptionAmount && subscriptionId) {
+      Logger.info(`Invoice ${invoiceId} is for early cancellation, cancelling subscription...`);
+      await stripePaymentsAdapter.deleteSubscription(subscriptionId);
       return;
     }
 
@@ -207,7 +215,7 @@ export class InvoiceCompletedHandler {
     productId: string;
     productType: string;
     planType: string;
-    maxSpaceBytes: string;
+    maxSpaceBytes?: string;
   } {
     const product = price?.product as Stripe.Product;
     const productId = product.id;

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -122,7 +122,6 @@ export default function (
           const determineLifetimeConditions = new DetermineLifetimeConditions(paymentService, tiersService);
           const objectStorageWebhookHandler = new ObjectStorageWebhookHandler(objectStorageService, paymentService);
           const handler = new InvoiceCompletedHandler({
-            logger: fastify.log,
             determineLifetimeConditions,
             objectStorageWebhookHandler,
             paymentService,

--- a/src/webhooks/providers/bit2me/index.ts
+++ b/src/webhooks/providers/bit2me/index.ts
@@ -107,7 +107,6 @@ export default function ({
       const objectStorageWebhookHandler = new ObjectStorageWebhookHandler(objectStorageService, paymentService);
 
       const handler = new InvoiceCompletedHandler({
-        logger: fastify.log,
         determineLifetimeConditions,
         objectStorageWebhookHandler,
         paymentService,

--- a/tests/src/controller/payments.controller.test.ts
+++ b/tests/src/controller/payments.controller.test.ts
@@ -630,7 +630,7 @@ describe('Payment controller e2e tests', () => {
   });
 
   describe('Cancel early charge', () => {
-    test('When the user wants to cancel the usb early, then we charge the 50% of the remaining amount', async () => {
+    test('When the user wants to cancel the sub early, then we charge the 50% of the remaining amount', async () => {
       const mockedClientSecret = 'client_secret_123';
       const mockedUser = getUser();
       const mockedToken = getValidAuthToken(mockedUser.uuid);

--- a/tests/src/controller/payments.controller.test.ts
+++ b/tests/src/controller/payments.controller.test.ts
@@ -24,7 +24,7 @@ import { LicenseCodesService } from '../../../src/services/licenseCodes.service'
 import { StripePaymentsAdapter } from '../../../src/infrastructure/adapters/stripe.adapter';
 import { Customer } from '../../../src/infrastructure/domain/entities/customer';
 import { UserType } from '../../../src/core/users/User';
-import { getPriceEntity } from '../entity.fixtures';
+import { getPriceEntity, getSubscriptionEntity } from '../entity.fixtures';
 
 jest.mock('../../../src/utils/assertUser');
 jest.mock('../../../src/services/storage.service', () => {
@@ -147,7 +147,7 @@ describe('Payment controller e2e tests', () => {
     });
   });
 
-  describe('Object storage tests', () => {
+  describe('Object storage', () => {
     describe('Create customer', () => {
       it('When the user exists, then its ID is returned with the user token', async () => {
         const mockCustomer = getCustomer();
@@ -626,6 +626,33 @@ describe('Payment controller e2e tests', () => {
 
       expect(response.statusCode).toBe(200);
       expect(body[0].interval).toBe('year');
+    });
+  });
+
+  describe('Cancel early charge', () => {
+    test('When the user wants to cancel the usb early, then we charge the 50% of the remaining amount', async () => {
+      const mockedClientSecret = 'client_secret_123';
+      const mockedUser = getUser();
+      const mockedToken = getValidAuthToken(mockedUser.uuid);
+      const mockedSubscriptionEntity = getSubscriptionEntity();
+
+      jest.spyOn(PaymentService.prototype, 'getActiveSubscriptionEntity').mockResolvedValue(mockedSubscriptionEntity);
+      jest.spyOn(PaymentService.prototype, 'createEarlyCancellationCharge').mockResolvedValue({
+        clientSecret: mockedClientSecret,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        path: '/subscriptions/cancel-early-charge',
+        headers: {
+          authorization: `Bearer ${mockedToken}`,
+        },
+      });
+
+      const body = response.json();
+
+      expect(response.statusCode).toBe(200);
+      expect(body).toStrictEqual({ clientSecret: mockedClientSecret });
     });
   });
 });

--- a/tests/src/fixtures.ts
+++ b/tests/src/fixtures.ts
@@ -467,6 +467,9 @@ export function getSubscription({
       commitment: {
         enabled: false,
       },
+      cancellation: {
+        scheduled: false,
+      },
       cancellationTrial: {
         redeemed: false,
       },

--- a/tests/src/helpers/services-factory.ts
+++ b/tests/src/helpers/services-factory.ts
@@ -22,7 +22,6 @@ import config from '../../../src/config';
 import { DetermineLifetimeConditions } from '../../../src/core/users/DetermineLifetimeConditions';
 import { ObjectStorageWebhookHandler } from '../../../src/webhooks/events/ObjectStorageWebhookHandler';
 import { InvoiceCompletedHandler } from '../../../src/webhooks/events/invoices/InvoiceCompletedHandler';
-import { getLogger } from '../fixtures';
 import { UserFeatureOverridesRepository } from '../../../src/core/users/MongoDBUserFeatureOverridesRepository';
 import { UserFeaturesOverridesService } from '../../../src/services/userFeaturesOverride.service';
 import { KlaviyoTrackingService } from '../../../src/services/klaviyo.service';
@@ -105,7 +104,6 @@ export const createTestServices = (overrides: TestServiceOverrides = {}): TestSe
   const determineLifetimeConditions = new DetermineLifetimeConditions(paymentService, tiersService);
   const objectStorageWebhookHandler = new ObjectStorageWebhookHandler(objectStorageService, paymentService);
   const invoiceCompletedHandler = new InvoiceCompletedHandler({
-    logger: getLogger(),
     determineLifetimeConditions,
     objectStorageWebhookHandler,
     paymentService,

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -1171,12 +1171,12 @@ describe('Payments Service tests', () => {
 
       jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(price);
-      const cancelSpy = jest.spyOn(stripe.subscriptions, 'cancel').mockResolvedValue(subscription as unknown as any);
+      const deleteSpy = jest.spyOn(stripePaymentsAdapter, 'deleteSubscription').mockResolvedValue();
       const updateSpy = jest.spyOn(stripe.subscriptions, 'update').mockResolvedValue(undefined as any);
 
       await paymentService.cancelSubscription(subscription.id);
 
-      expect(cancelSpy).toHaveBeenCalledWith(subscription.id, {});
+      expect(deleteSpy).toHaveBeenCalledWith(subscription.id);
       expect(updateSpy).not.toHaveBeenCalled();
 
       jest.useRealTimers();
@@ -1188,12 +1188,12 @@ describe('Payments Service tests', () => {
 
       jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(price);
-      const cancelSpy = jest.spyOn(stripe.subscriptions, 'cancel').mockResolvedValue(subscription as unknown as any);
+      const deleteSpy = jest.spyOn(stripePaymentsAdapter, 'deleteSubscription').mockResolvedValue();
       const updateSpy = jest.spyOn(stripe.subscriptions, 'update').mockResolvedValue(undefined as any);
 
       await paymentService.cancelSubscription(subscription.id);
 
-      expect(cancelSpy).toHaveBeenCalledWith(subscription.id, {});
+      expect(deleteSpy).toHaveBeenCalledWith(subscription.id);
       expect(updateSpy).not.toHaveBeenCalled();
     });
   });
@@ -1294,7 +1294,7 @@ describe('Payments Service tests', () => {
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(customerEntity);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(priceEntity);
 
-      await expect(paymentService.chargeRemainingSubscriptionAmount(subscription)).rejects.toThrow(
+      await expect(paymentService.createEarlyCancellationCharge(subscription)).rejects.toThrow(
         SubscriptionNotEligibleForEarlyChargeError,
       );
     });
@@ -1304,7 +1304,7 @@ describe('Payments Service tests', () => {
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(customerEntity);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(priceEntity);
 
-      await expect(paymentService.chargeRemainingSubscriptionAmount(subscription)).rejects.toThrow(
+      await expect(paymentService.createEarlyCancellationCharge(subscription)).rejects.toThrow(
         PaymentMethodNotFoundError,
       );
     });
@@ -1320,7 +1320,7 @@ describe('Payments Service tests', () => {
       jest.spyOn(stripePaymentsAdapter, 'addInvoiceItems').mockResolvedValue(invoiceEntity);
       jest.spyOn(stripePaymentsAdapter, 'finalizeInvoice').mockResolvedValue(invoiceEntity);
 
-      await expect(paymentService.chargeRemainingSubscriptionAmount(subscription)).rejects.toThrow(
+      await expect(paymentService.createEarlyCancellationCharge(subscription)).rejects.toThrow(
         ClientSecretNotFoundError,
       );
     });
@@ -1340,7 +1340,7 @@ describe('Payments Service tests', () => {
         .mockResolvedValue(invoiceItemsEntity);
       jest.spyOn(stripePaymentsAdapter, 'finalizeInvoice').mockResolvedValue(invoiceEntity);
 
-      const result = await paymentService.chargeRemainingSubscriptionAmount(subscription);
+      const result = await paymentService.createEarlyCancellationCharge(subscription);
 
       expect(result).toStrictEqual({ clientSecret: expectedClientSecret });
       expect(addInvoiceItemsSpy).toHaveBeenCalledWith(

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -1256,6 +1256,7 @@ describe('Payments Service tests', () => {
         { created: dayjs('2025-10-01T00:00:00Z').unix() },
       );
       jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([subscription]);
+      jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(getPriceEntity());
       mockUpcomingInvoice();
 
       const result = await paymentService.getUserSubscription('cus_test', UserType.Individual);

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -1171,7 +1171,7 @@ describe('Payments Service tests', () => {
 
       jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(price);
-      const deleteSpy = jest.spyOn(stripePaymentsAdapter, 'deleteSubscription').mockResolvedValue();
+      const deleteSpy = jest.spyOn(stripePaymentsAdapter, 'cancelSubscription').mockResolvedValue();
       const updateSpy = jest.spyOn(stripe.subscriptions, 'update').mockResolvedValue(undefined as any);
 
       await paymentService.cancelSubscription(subscription.id);
@@ -1188,7 +1188,7 @@ describe('Payments Service tests', () => {
 
       jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(price);
-      const deleteSpy = jest.spyOn(stripePaymentsAdapter, 'deleteSubscription').mockResolvedValue();
+      const deleteSpy = jest.spyOn(stripePaymentsAdapter, 'cancelSubscription').mockResolvedValue();
       const updateSpy = jest.spyOn(stripe.subscriptions, 'update').mockResolvedValue(undefined as any);
 
       await paymentService.cancelSubscription(subscription.id);

--- a/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
+++ b/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
@@ -248,7 +248,7 @@ describe('Testing the handler when an invoice is completed', () => {
         status: mockedInvoice.status as string,
       };
 
-      const cancelSubscriptionSpy = jest.spyOn(stripePaymentsAdapter, 'deleteSubscription').mockResolvedValue();
+      const cancelSubscriptionSpy = jest.spyOn(stripePaymentsAdapter, 'cancelSubscription').mockResolvedValue();
 
       await invoiceCompletedHandler.run(invoiceCompletedHandlerPayload);
 

--- a/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
+++ b/tests/src/webhooks/events/invoices/InvoiceCompletedHandler.test.ts
@@ -10,6 +10,8 @@ import { createTestServices } from '../../../helpers/services-factory';
 import { UserNotFoundError } from '../../../../../src/errors/PaymentErrors';
 import { Customer } from '../../../../../src/infrastructure/domain/entities/customer';
 import { CouponNotBeingTrackedError } from '../../../../../src/errors/UsersErrors';
+import { SUBSCRIPTION_EARLY_CANCELLATION_KEY } from '../../../../../src/constants';
+import { stripePaymentsAdapter } from '../../../../../src/infrastructure/adapters/stripe.adapter';
 
 const {
   invoiceCompletedHandler,
@@ -227,6 +229,30 @@ describe('Testing the handler when an invoice is completed', () => {
         userId: mockedUser.id,
         newTier: mockedTier,
       });
+    });
+  });
+
+  describe('Invoice for early cancellation', () => {
+    test('When the invoices is for early cancellation, then the subscription is cancelled and early returned', async () => {
+      const mockedInvoice = getInvoice({
+        status: 'paid',
+        metadata: {
+          type: SUBSCRIPTION_EARLY_CANCELLATION_KEY,
+          subscriptionId: 'sub_123',
+        },
+      });
+
+      const invoiceCompletedHandlerPayload: InvoiceCompletedHandlerPayload = {
+        customer: Customer.toDomain(getCustomer()),
+        invoice: mockedInvoice,
+        status: mockedInvoice.status as string,
+      };
+
+      const cancelSubscriptionSpy = jest.spyOn(stripePaymentsAdapter, 'deleteSubscription').mockResolvedValue();
+
+      await invoiceCompletedHandler.run(invoiceCompletedHandlerPayload);
+
+      expect(cancelSubscriptionSpy).toHaveBeenCalledWith(mockedInvoice.metadata?.subscriptionId as string);
     });
   });
 


### PR DESCRIPTION
Exposing the endpoint to allow the users to cancel the subscription at the moment by paying the 50% of the remaining amount.

We also handle the logic in the `invoice.paid` webhook event to cancel the subscription.