### PR TITLE
[PB-6369]: Feature/reactivate subscription

### DIFF
--- a/src/controller/payments.controller.ts
+++ b/src/controller/payments.controller.ts
@@ -284,6 +284,15 @@ export function paymentsController(
       return rep.send({ clientSecret });
     });
 
+    fastify.post('/subscriptions/reactivate', async (req: FastifyRequest, rep: FastifyReply) => {
+      const user = await assertUser(req, rep, usersService);
+
+      const subscription = await paymentService.getActiveSubscriptionEntity(user.customerId, UserType.Individual);
+
+      await paymentService.reactivateSubscription(subscription.id);
+      return rep.status(204).send();
+    });
+
     fastify.post<{
       Body: { customerId: string };
     }>(

--- a/src/infrastructure/adapters/stripe.adapter.ts
+++ b/src/infrastructure/adapters/stripe.adapter.ts
@@ -148,6 +148,7 @@ export class StripePaymentsAdapter implements PaymentsAdapter {
       metadata: subscription.metadata,
       trialEnd: subscription.trial_end ?? undefined,
       paymentMethod,
+      cancelAt: subscription.cancel_at ?? undefined,
     });
   }
 

--- a/src/infrastructure/domain/entities/subscription.ts
+++ b/src/infrastructure/domain/entities/subscription.ts
@@ -11,6 +11,7 @@ export interface SubscriptionAttributes {
   currentPeriodEnd: number;
   paymentMethod?: string;
   trialEnd?: number;
+  cancelAt?: number;
 }
 
 export interface CommitmentCancellationInfo {
@@ -30,6 +31,7 @@ export class Subscription implements SubscriptionAttributes {
   currentPeriodEnd: number;
   paymentMethod?: string;
   trialEnd?: number;
+  cancelAt?: number;
 
   constructor({
     id,
@@ -41,6 +43,7 @@ export class Subscription implements SubscriptionAttributes {
     currentPeriodEnd,
     paymentMethod,
     trialEnd,
+    cancelAt,
   }: SubscriptionAttributes) {
     this.id = id;
     this.customer = customer;
@@ -51,6 +54,7 @@ export class Subscription implements SubscriptionAttributes {
     this.currentPeriodEnd = currentPeriodEnd;
     this.trialEnd = trialEnd;
     this.paymentMethod = paymentMethod;
+    this.cancelAt = cancelAt;
   }
 
   static toDomain(attributes: SubscriptionAttributes): Subscription {
@@ -63,5 +67,9 @@ export class Subscription implements SubscriptionAttributes {
 
   get isTrialing(): boolean {
     return this.status === 'trialing';
+  }
+
+  get hasScheduledCancellation(): boolean {
+    return !!this.cancelAt;
   }
 }

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -465,6 +465,21 @@ export class PaymentService {
     await stripePaymentsAdapter.cancelSubscription(subscriptionId);
   }
 
+  /**
+   * Reverts a scheduled cancellation (cancel_at) so the subscription keeps renewing.
+   */
+  async reactivateSubscription(subscriptionId: SubscriptionId): Promise<void> {
+    const subscription = await stripePaymentsAdapter.getSubscription(subscriptionId);
+
+    if (!subscription.hasScheduledCancellation) {
+      throw new BadRequestError('The subscription has no scheduled cancellation to revert');
+    }
+
+    await stripePaymentsAdapter.updateSubscription(subscriptionId, {
+      cancel_at: '',
+    });
+  }
+
   private calculateRemainingSubscriptionAmount(price: Price, remainingMonths: number): number {
     const subscriptionAmount = price.amount;
     const remainingAmount = subscriptionAmount * remainingMonths;

--- a/tests/src/controller/payments.controller.test.ts
+++ b/tests/src/controller/payments.controller.test.ts
@@ -655,4 +655,27 @@ describe('Payment controller e2e tests', () => {
       expect(body).toStrictEqual({ clientSecret: mockedClientSecret });
     });
   });
+
+  describe('Reactivate subscription', () => {
+    test('When the user reverts a scheduled cancellation, then the subscription is reactivated and a 204 is returned', async () => {
+      const mockedUser = getUser();
+      const mockedToken = getValidAuthToken(mockedUser.uuid);
+      const mockedSubscriptionEntity = getSubscriptionEntity();
+
+      (assertUser as jest.Mock).mockResolvedValue(mockedUser);
+      jest.spyOn(PaymentService.prototype, 'getActiveSubscriptionEntity').mockResolvedValue(mockedSubscriptionEntity);
+      const reactivateSpy = jest.spyOn(PaymentService.prototype, 'reactivateSubscription').mockResolvedValue();
+
+      const response = await app.inject({
+        method: 'POST',
+        path: '/subscriptions/reactivate',
+        headers: {
+          authorization: `Bearer ${mockedToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(reactivateSpy).toHaveBeenCalledWith(mockedSubscriptionEntity.id);
+    });
+  });
 });

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -1198,6 +1198,29 @@ describe('Payments Service tests', () => {
     });
   });
 
+  describe('Reactivating a subscription', () => {
+    test('when the subscription has a scheduled cancellation, then it clears the cancel_at so it keeps renewing', async () => {
+      const subscription = getSubscriptionEntity({ cancelAt: dayjs().add(1, 'month').unix() });
+
+      jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
+      const updateSpy = jest.spyOn(stripePaymentsAdapter, 'updateSubscription').mockResolvedValue(subscription);
+
+      await paymentService.reactivateSubscription(subscription.id);
+
+      expect(updateSpy).toHaveBeenCalledWith(subscription.id, { cancel_at: '' });
+    });
+
+    test('when the subscription has no scheduled cancellation, then an error is thrown and no update is made', async () => {
+      const subscription = getSubscriptionEntity({ cancelAt: undefined });
+
+      jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
+      const updateSpy = jest.spyOn(stripePaymentsAdapter, 'updateSubscription').mockResolvedValue(subscription);
+
+      await expect(paymentService.reactivateSubscription(subscription.id)).rejects.toThrow(BadRequestError);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Getting the user subscription', () => {
     const makeActiveSubscription = (priceMetadata: Record<string, string> = {}, overrides = {}) => {
       const base = getCreatedSubscription();


### PR DESCRIPTION
Reactivating the user subscription if this one has been scheduled for cancellation before. This allows the user to reactivate a subscription without going to Billing, selecting a new sub and completing the checkout.