### PR TITLE
[MKT_923]:feat/Relax required fields on POST /customer to match new checkout flow

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -20,12 +20,12 @@ export function checkoutController(usersService: UsersService, paymentsService: 
 
     fastify.post<{
       Body: {
-        customerName: string;
-        lineAddress1: string;
-        lineAddress2: string;
-        city: string;
+        customerName?: string;
+        lineAddress1?: string;
+        lineAddress2?: string;
+        city?: string;
         country: string;
-        postalCode: string;
+        postalCode?: string;
         captchaToken: string;
         companyVatId?: string;
         metadata?: Record<string, string>;
@@ -36,7 +36,7 @@ export function checkoutController(usersService: UsersService, paymentsService: 
         schema: {
           body: {
             type: 'object',
-            required: ['customerName', 'lineAddress1', 'city', 'country', 'postalCode', 'captchaToken'],
+            required: ['country', 'captchaToken'],
             properties: {
               customerName: { type: 'string' },
               lineAddress1: { type: 'string' },


### PR DESCRIPTION
This PR Makes `customerName`, `lineAddress1`, `lineAddress2`, `city` and `postalCode` optional in the `POST /customer` body, keeping only `country` and `captchaToken` as required. The new checkout flow no longer collects full billing address up front for card payments, full address is only gathered for crypto payments. Matches the `CreateCustomerPayload` type already relaxed in `@internxt/sdk@1.17.19`.