### PR TITLE
[MKT_923]:fix/prevent checkout crash when Stripe cannot geolocate the user IP

### DIFF
--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -376,7 +376,7 @@ export function checkoutController(usersService: UsersService, paymentsService: 
           }
         }
 
-        if (userAddress || (postalCode && country) || user?.customerId) {
+        if (currency === 'eur' && (userAddress || (postalCode && country) || user?.customerId)) {
           taxForPrice = await paymentsService.calculateTax(
             priceId,
             amount,
@@ -389,7 +389,7 @@ export function checkoutController(usersService: UsersService, paymentsService: 
         }
 
         const taxAmount = taxForPrice?.tax_amount_exclusive ?? 0;
-        const amountTotal = taxForPrice?.amount_total ?? price.amount;
+        const amountTotal = taxForPrice?.amount_total ?? amount;
 
         return res.status(200).send({
           price: price.toJSON(),

--- a/src/controller/checkout.controller.ts
+++ b/src/controller/checkout.controller.ts
@@ -363,6 +363,9 @@ export function checkoutController(usersService: UsersService, paymentsService: 
 
         const price = await stripePaymentsAdapter.getPriceById(priceId, currency);
 
+        const isEuroCurrency = currency === 'eur';
+        const isUserAddressProvided = !!userAddress || (!!postalCode && !!country) || !!user?.customerId;
+
         let amount = price.amount;
 
         if (promoCodeName) {
@@ -376,7 +379,7 @@ export function checkoutController(usersService: UsersService, paymentsService: 
           }
         }
 
-        if (currency === 'eur' && (userAddress || (postalCode && country) || user?.customerId)) {
+        if (isEuroCurrency && isUserAddressProvided) {
           taxForPrice = await paymentsService.calculateTax(
             priceId,
             amount,

--- a/src/errors/stripeErrorCodes.ts
+++ b/src/errors/stripeErrorCodes.ts
@@ -1,0 +1,1 @@
+export const STRIPE_TAX_LOCATION_INVALID_CODE = 'customer_tax_location_invalid';

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -45,6 +45,7 @@ import {
   Subscription as SubscriptionEntity,
 } from '../infrastructure/domain/entities/subscription';
 import { SUBSCRIPTION_EARLY_CANCELLATION_KEY } from '../constants';
+import { STRIPE_TAX_LOCATION_INVALID_CODE } from '../errors/stripeErrorCodes';
 import { Price } from '../infrastructure/domain/entities/price';
 
 export class PaymentService {
@@ -1028,7 +1029,6 @@ export class PaymentService {
     country?: string,
   ): Promise<Stripe.Tax.Calculation | undefined> {
     const customerDetails: Stripe.Tax.CalculationCreateParams.CustomerDetails = {};
-    const usingIpAddress = !(postalCode && country);
 
     if (postalCode && country) {
       customerDetails.address = {
@@ -1056,13 +1056,10 @@ export class PaymentService {
       });
     } catch (error) {
       const isInsufficientLocationError =
-        usingIpAddress &&
-        !customerId &&
-        error instanceof Stripe.errors.StripeError &&
-        error.message?.includes('insufficient to determine');
+        error instanceof Stripe.errors.StripeError && error.code === STRIPE_TAX_LOCATION_INVALID_CODE;
 
       if (isInsufficientLocationError) {
-        Logger.warn(`Tax calculation skipped: IP ${ipAddress} is insufficient to determine tax location`);
+        Logger.error('Tax calculation skipped: location is insufficient to determine the tax jurisdiction');
         return undefined;
       }
 

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1026,8 +1026,9 @@ export class PaymentService {
     customerId?: string,
     postalCode?: string,
     country?: string,
-  ): Promise<Stripe.Tax.Calculation> {
+  ): Promise<Stripe.Tax.Calculation | undefined> {
     const customerDetails: Stripe.Tax.CalculationCreateParams.CustomerDetails = {};
+    const usingIpAddress = !(postalCode && country);
 
     if (postalCode && country) {
       customerDetails.address = {
@@ -1039,19 +1040,34 @@ export class PaymentService {
       customerDetails.ip_address = ipAddress;
     }
 
-    return this.provider.tax.calculations.create({
-      customer: customerId,
-      customer_details: customerId ? undefined : customerDetails,
-      line_items: [
-        {
-          amount,
-          reference: priceId,
-          tax_behavior: 'exclusive',
-          quantity: 1,
-        },
-      ],
-      currency,
-    });
+    try {
+      return await this.provider.tax.calculations.create({
+        customer: customerId,
+        customer_details: customerId ? undefined : customerDetails,
+        line_items: [
+          {
+            amount,
+            reference: priceId,
+            tax_behavior: 'exclusive',
+            quantity: 1,
+          },
+        ],
+        currency,
+      });
+    } catch (error) {
+      const isInsufficientLocationError =
+        usingIpAddress &&
+        !customerId &&
+        error instanceof Stripe.errors.StripeError &&
+        error.message?.includes('insufficient to determine');
+
+      if (isInsufficientLocationError) {
+        Logger.warn(`Tax calculation skipped: IP ${ipAddress} is insufficient to determine tax location`);
+        return undefined;
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -44,6 +44,7 @@ import {
   PaymentMethodNotFoundError,
   SubscriptionNotEligibleForEarlyChargeError,
 } from '../../../src/errors/PaymentErrors';
+import { STRIPE_TAX_LOCATION_INVALID_CODE } from '../../../src/errors/stripeErrorCodes';
 
 describe('Payments Service tests', () => {
   const { paymentService, stripe, bit2MeService } = createTestServices();
@@ -714,7 +715,7 @@ describe('Payments Service tests', () => {
   });
 
   describe('Get tax for a price', () => {
-    it('When the params are correct, then a tax object is returned for the requested price', async () => {
+    test('When the params are correct, then a tax object is returned for the requested price', async () => {
       const mockedPrice = getPrice();
       const mockedTaxes = getTaxes();
       jest
@@ -726,11 +727,12 @@ describe('Payments Service tests', () => {
       expect(taxes).toStrictEqual(mockedTaxes);
     });
 
-    it('When the IP cannot be geolocated to a tax jurisdiction, then no tax is returned so the price still loads', async () => {
+    test('When the location is not enough to determine the tax jurisdiction, then no tax is returned so the price still loads', async () => {
       const mockedPrice = getPrice();
       const insufficientLocationError = new Stripe.errors.StripeInvalidRequestError({
         message: "The IP address provided is insufficient to determine the customer's tax location.",
         type: 'invalid_request_error',
+        code: STRIPE_TAX_LOCATION_INVALID_CODE,
       });
       jest.spyOn(stripe.tax.calculations, 'create').mockRejectedValue(insufficientLocationError);
 
@@ -739,11 +741,33 @@ describe('Payments Service tests', () => {
       expect(taxes).toBeUndefined();
     });
 
-    it('When Stripe fails for an unrelated reason, then the error is propagated', async () => {
+    test('When the stored customer address is not enough to determine the tax jurisdiction, then no tax is returned so the price still loads', async () => {
       const mockedPrice = getPrice();
-      const unexpectedError = new Stripe.errors.StripeAPIError({
-        message: 'Something went wrong on our end.',
-        type: 'api_error',
+      const customerId = 'cus_customer_with_incomplete_address';
+      const insufficientLocationError = new Stripe.errors.StripeInvalidRequestError({
+        message: "The customer's address is missing or invalid for tax purposes.",
+        type: 'invalid_request_error',
+        code: STRIPE_TAX_LOCATION_INVALID_CODE,
+      });
+      jest.spyOn(stripe.tax.calculations, 'create').mockRejectedValue(insufficientLocationError);
+
+      const taxes = await paymentService.calculateTax(
+        mockedPrice.id,
+        mockedPrice.unit_amount as number,
+        undefined,
+        'eur',
+        customerId,
+      );
+
+      expect(taxes).toBeUndefined();
+    });
+
+    test('When Stripe fails for an unrelated reason, then the error is propagated', async () => {
+      const mockedPrice = getPrice();
+      const unexpectedError = new Stripe.errors.StripeInvalidRequestError({
+        message: 'No such price.',
+        type: 'invalid_request_error',
+        code: 'resource_missing',
       });
       jest.spyOn(stripe.tax.calculations, 'create').mockRejectedValue(unexpectedError);
 

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -725,6 +725,32 @@ describe('Payments Service tests', () => {
 
       expect(taxes).toStrictEqual(mockedTaxes);
     });
+
+    it('When the IP cannot be geolocated to a tax jurisdiction, then no tax is returned so the price still loads', async () => {
+      const mockedPrice = getPrice();
+      const insufficientLocationError = new Stripe.errors.StripeInvalidRequestError({
+        message: "The IP address provided is insufficient to determine the customer's tax location.",
+        type: 'invalid_request_error',
+      });
+      jest.spyOn(stripe.tax.calculations, 'create').mockRejectedValue(insufficientLocationError);
+
+      const taxes = await paymentService.calculateTax(mockedPrice.id, mockedPrice.unit_amount as number, 'user_ip');
+
+      expect(taxes).toBeUndefined();
+    });
+
+    it('When Stripe fails for an unrelated reason, then the error is propagated', async () => {
+      const mockedPrice = getPrice();
+      const unexpectedError = new Stripe.errors.StripeAPIError({
+        message: 'Something went wrong on our end.',
+        type: 'api_error',
+      });
+      jest.spyOn(stripe.tax.calculations, 'create').mockRejectedValue(unexpectedError);
+
+      await expect(
+        paymentService.calculateTax(mockedPrice.id, mockedPrice.unit_amount as number, 'user_ip'),
+      ).rejects.toThrow(unexpectedError);
+    });
   });
 
   describe('Get Promotion Code', () => {


### PR DESCRIPTION
We were experiencing a problem where, when a user was geolocated in a region (for example Canada) that requires a sub-national jurisdiction (zip code and country) for tax calculations, we normally use the IP address, but in these cases that is insufficient. The error we encountered was: “The IP address provided is insufficient to determine the customer's tax location. Please provide an alternative address.”

To resolve this, we’ve made a couple of adjustments:
- Calculate taxes only when working with euros. This was discussed yesterday during a call and proposed because it appears to be too costly for us, it’s an additional measure beyond the fix.
- We updated the `calculateTax` function to allow it to return `undefined` if we encounter the specific error we’re discussing. To do this, we created the `isInsufficientLocationError` exception.
- Tests: Added two cases :
              1. IP cannot be geolocated → returns `undefined`
              2. another Stripe error → propagates.