### PR TITLE
[_]: fix/use startDate instead of created

### DIFF
--- a/src/infrastructure/adapters/stripe.adapter.ts
+++ b/src/infrastructure/adapters/stripe.adapter.ts
@@ -123,7 +123,7 @@ export class StripePaymentsAdapter implements PaymentsAdapter {
       priceId: subscription.items.data[0].price.id,
       currentPeriodEnd: subscription.current_period_end,
       metadata: subscription.metadata,
-      created: subscription.created,
+      startDate: subscription.start_date,
       trialEnd: subscription.trial_end ?? undefined,
     });
   }
@@ -144,7 +144,7 @@ export class StripePaymentsAdapter implements PaymentsAdapter {
       status: subscription.status,
       currentPeriodEnd: subscription.current_period_end,
       priceId: subscription.items.data[0].price.id,
-      created: subscription.created,
+      startDate: subscription.start_date,
       metadata: subscription.metadata,
       trialEnd: subscription.trial_end ?? undefined,
       paymentMethod,

--- a/src/infrastructure/domain/entities/subscription.ts
+++ b/src/infrastructure/domain/entities/subscription.ts
@@ -6,7 +6,7 @@ export interface SubscriptionAttributes {
   customer: string;
   status: SubscriptionStatus;
   metadata: Record<string, unknown>;
-  created: number;
+  startDate: number;
   priceId: string;
   currentPeriodEnd: number;
   paymentMethod?: string;
@@ -26,7 +26,7 @@ export class Subscription implements SubscriptionAttributes {
   customer: string;
   status: SubscriptionStatus;
   metadata: Record<string, unknown>;
-  created: number;
+  startDate: number;
   priceId: string;
   currentPeriodEnd: number;
   paymentMethod?: string;
@@ -38,7 +38,7 @@ export class Subscription implements SubscriptionAttributes {
     customer,
     metadata,
     status,
-    created,
+    startDate,
     priceId,
     currentPeriodEnd,
     paymentMethod,
@@ -49,7 +49,7 @@ export class Subscription implements SubscriptionAttributes {
     this.customer = customer;
     this.status = status;
     this.metadata = metadata;
-    this.created = created;
+    this.startDate = startDate;
     this.priceId = priceId;
     this.currentPeriodEnd = currentPeriodEnd;
     this.trialEnd = trialEnd;

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -431,7 +431,8 @@ export class PaymentService {
    * @returns - The annual commitment cancellation info (remaining payments, amount per month, currency, cancel at)
    */
   getAnnualCommitmentCancellationInfo(subscription: SubscriptionEntity): CommitmentCancellationInfo {
-    const createdAt = dayjs.unix(subscription.created);
+    const subscriptionStartedAt = subscription.startDate;
+    const createdAt = dayjs.unix(subscriptionStartedAt);
     const now = dayjs();
 
     const monthsElapsed = now.diff(createdAt, 'month');
@@ -1213,7 +1214,7 @@ export class PaymentService {
       customer: subscription.customer as string,
       status: subscription.status,
       metadata: subscription.metadata,
-      created: subscription.created,
+      startDate: subscription.start_date,
       priceId: subscription.items.data[0].price.id,
       currentPeriodEnd: subscription.current_period_end,
       paymentMethod:

--- a/tests/src/entity.fixtures.ts
+++ b/tests/src/entity.fixtures.ts
@@ -75,7 +75,7 @@ export const getSubscriptionEntity = (params?: Partial<SubscriptionAttributes>):
     id: `sub_${randomGenerator.string({ length: 14, alpha: true, numeric: true })}`,
     customer: `cus_${randomGenerator.string({ length: 14, alpha: true, numeric: true })}`,
     metadata: {},
-    created: dayjs().unix(),
+    startDate: dayjs().unix(),
     priceId: `price_${randomGenerator.string({ length: 14, alpha: true, numeric: true })}`,
     currentPeriodEnd: dayjs().add(1, 'month').unix(),
     status: randomGenerator.pickone(['active', 'trialing', 'past_due', 'canceled']),

--- a/tests/src/infrastructure/adapters/stripe.adapter.test.ts
+++ b/tests/src/infrastructure/adapters/stripe.adapter.test.ts
@@ -421,7 +421,7 @@ describe('Stripe Adapter', () => {
           priceId: stripeSubscription.items.data[0].price.id,
           currentPeriodEnd: stripeSubscription.current_period_end,
           metadata: stripeSubscription.metadata,
-          created: stripeSubscription.created,
+          startDate: stripeSubscription.start_date,
         }),
       );
     });
@@ -457,7 +457,7 @@ describe('Stripe Adapter', () => {
           status: stripeSubscription.status,
           currentPeriodEnd: stripeSubscription.current_period_end,
           priceId: stripeSubscription.items.data[0].price.id,
-          created: stripeSubscription.created,
+          startDate: stripeSubscription.start_date,
           metadata: stripeSubscription.metadata,
           trialEnd: undefined,
           paymentMethod: (stripeSubscription.default_payment_method as Stripe.PaymentMethod).id as string,

--- a/tests/src/services/payment.service.test.ts
+++ b/tests/src/services/payment.service.test.ts
@@ -1113,7 +1113,7 @@ describe('Payments Service tests', () => {
       jest.setSystemTime(dayjs('2026-05-05T10:00:00Z').toDate());
 
       const subscriptionEntity = getSubscriptionEntity({
-        created: dayjs('2026-05-01T00:00:00Z').unix(),
+        startDate: dayjs('2026-05-01T00:00:00Z').unix(),
       });
       const { remainingMonths, cancelAt } = paymentService.getAnnualCommitmentCancellationInfo(subscriptionEntity);
 
@@ -1126,7 +1126,7 @@ describe('Payments Service tests', () => {
       jest.setSystemTime(dayjs('2026-05-05T10:00:00Z').toDate());
 
       const subscriptionEntity = getSubscriptionEntity({
-        created: dayjs('2025-10-01T00:00:00Z').unix(),
+        startDate: dayjs('2025-10-01T00:00:00Z').unix(),
       });
       const { remainingMonths } = paymentService.getAnnualCommitmentCancellationInfo(subscriptionEntity);
 
@@ -1136,7 +1136,7 @@ describe('Payments Service tests', () => {
     test('when the user completes exactly 12 months and starts a new period, then they have 12 remaining payments again', () => {
       jest.setSystemTime(dayjs('2026-10-01T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2025-10-01T00:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2025-10-01T00:00:00Z').unix() });
       const { remainingMonths, cancelAt } = paymentService.getAnnualCommitmentCancellationInfo(subscription);
 
       expect(remainingMonths).toBe(12);
@@ -1146,7 +1146,7 @@ describe('Payments Service tests', () => {
     test('when the user has been subscribed for 14 months, then they have 10 remaining payments and cancel date is in the second year', () => {
       jest.setSystemTime(dayjs('2026-12-01T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2025-10-01T00:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2025-10-01T00:00:00Z').unix() });
       const { remainingMonths, cancelAt } = paymentService.getAnnualCommitmentCancellationInfo(subscription);
 
       expect(remainingMonths).toBe(10);
@@ -1156,7 +1156,7 @@ describe('Payments Service tests', () => {
     test('when the user has 1 month left in the period, then they have 1 remaining payment', () => {
       jest.setSystemTime(dayjs('2026-09-01T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2025-10-01T00:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2025-10-01T00:00:00Z').unix() });
       const { remainingMonths } = paymentService.getAnnualCommitmentCancellationInfo(subscription);
 
       expect(remainingMonths).toBe(1);
@@ -1165,7 +1165,7 @@ describe('Payments Service tests', () => {
     test('when the user subscribed less than 30 days ago, then they are still in their first month', () => {
       jest.setSystemTime(dayjs('2026-05-05T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2026-04-28T10:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2026-04-28T10:00:00Z').unix() });
       const { isElegibleForCancellation } = paymentService.getAnnualCommitmentCancellationInfo(subscription);
 
       expect(isElegibleForCancellation).toBe(true);
@@ -1174,7 +1174,7 @@ describe('Payments Service tests', () => {
     test('when the user subscribed more than 30 days ago, then they are no longer in their first month', () => {
       jest.setSystemTime(dayjs('2026-05-05T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2026-03-01T10:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2026-03-01T10:00:00Z').unix() });
       const { isElegibleForCancellation } = paymentService.getAnnualCommitmentCancellationInfo(subscription);
 
       expect(isElegibleForCancellation).toBe(false);
@@ -1183,7 +1183,7 @@ describe('Payments Service tests', () => {
     test('when the user has completed a full year and starts a new cycle, then they are not considered in their first month', () => {
       jest.setSystemTime(dayjs('2026-10-01T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2025-10-01T00:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2025-10-01T00:00:00Z').unix() });
       const { isElegibleForCancellation } = paymentService.getAnnualCommitmentCancellationInfo(subscription);
 
       expect(isElegibleForCancellation).toBe(false);
@@ -1195,7 +1195,7 @@ describe('Payments Service tests', () => {
       jest.useFakeTimers();
       jest.setSystemTime(dayjs('2026-05-05T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2025-10-01T00:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2025-10-01T00:00:00Z').unix() });
       const price = getPriceEntity({ commitmentPlan: true });
 
       jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
@@ -1205,7 +1205,7 @@ describe('Payments Service tests', () => {
 
       await paymentService.cancelSubscription(subscription.id);
 
-      const expectedCancelAt = dayjs.unix(subscription.created).add(1, 'year').unix();
+      const expectedCancelAt = dayjs.unix(subscription.startDate).add(1, 'year').unix();
       expect(updateSpy).toHaveBeenCalledWith(subscription.id, { cancel_at: expectedCancelAt });
       expect(cancelSpy).not.toHaveBeenCalled();
 
@@ -1216,7 +1216,7 @@ describe('Payments Service tests', () => {
       jest.useFakeTimers();
       jest.setSystemTime(dayjs('2026-05-05T10:00:00Z').toDate());
 
-      const subscription = getSubscriptionEntity({ created: dayjs('2026-04-28T00:00:00Z').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs('2026-04-28T00:00:00Z').unix() });
       const price = getPriceEntity({ commitmentPlan: true });
 
       jest.spyOn(stripePaymentsAdapter, 'getSubscription').mockResolvedValue(subscription);
@@ -1326,7 +1326,7 @@ describe('Payments Service tests', () => {
 
       const subscription = makeActiveSubscription(
         { annualCommitment: 'true' },
-        { created: dayjs('2025-10-01T00:00:00Z').unix() },
+        { start_date: dayjs('2025-10-01T00:00:00Z').unix() },
       );
       jest.spyOn(paymentService, 'getActiveSubscriptions').mockResolvedValue([subscription]);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(getPriceEntity());
@@ -1364,7 +1364,7 @@ describe('Payments Service tests', () => {
     const customerEntity = getCustomerEntity();
     const priceEntity = getPriceEntity();
     test('When the user subscription ends this month(last month of commitment), then an error indicating so is thrown', async () => {
-      const subscription = getSubscriptionEntity({ created: dayjs().subtract(11, 'month').unix() });
+      const subscription = getSubscriptionEntity({ startDate: dayjs().subtract(11, 'month').unix() });
       jest.spyOn(stripePaymentsAdapter, 'getCustomer').mockResolvedValue(customerEntity);
       jest.spyOn(stripePaymentsAdapter, 'getPriceById').mockResolvedValue(priceEntity);
 


### PR DESCRIPTION
We're changing the parameter we use to determine when a subscription began:
- `created` (previously used): the date when the subscription object was created in Stripe.
- `startDate` (used now): the date when the subscription actually started.

With this change, we can properly test the new cancellation flow. For example, we can manually create a subscription in the Stripe Dashboard with a start date in the past, allowing the commitment period to be calculated correctly.
